### PR TITLE
feat: add vui-components.el with vui-collapsible

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,11 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 * Unreleased
 
+** Added
+
+- *vui-components.el*: New component library with higher-level components built on vui primitives.
+- =vui-collapsible=: Togglable section that expands/collapses content. Supports both uncontrolled (manages own state) and controlled (=:expanded= prop) modes. Features customizable indicators, title face, indentation, and proper nested indentation via context propagation.
+
 ** Fixed
 
 - *Keymap hierarchy*: =special-mode-map= bindings (like =h= for help) were inaccessible because =set-keymap-parent= overwrote the parent set by =define-derived-mode=. Now uses =make-composed-keymap= to include both =widget-keymap= and =special-mode-map=.

--- a/README.org
+++ b/README.org
@@ -176,6 +176,7 @@ See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:
 - [[file:docs/examples/03-forms.el][Forms]] — Form validation, multi-step wizards, settings
 - [[file:docs/examples/04-file-browser.el][File Browser]] — Directory navigation with sorting and search
 - [[file:docs/examples/05-wine-tasting.el][Wine Tasting]] — Dynamic tables with interactive cells, computed statistics
+- [[file:docs/examples/06-collapsible.el][Collapsible]] — Expandable/collapsible sections, FAQ style, nested sections
 
 * Available Components
 
@@ -201,6 +202,22 @@ See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:
 | =vui-box=    | Fixed-width container with alignment   |
 | =vui-table=  | Table with headers, borders, alignment |
 | =vui-list=   | Dynamic list with key-based reconcile  |
+
+** Higher-Level Components (vui-components.el)
+
+| Component          | Description                              |
+|--------------------+------------------------------------------|
+| =vui-collapsible=  | Expandable/collapsible section with header |
+
+#+begin_src elisp
+(require 'vui-components)
+
+(vui-collapsible :title "FAQ"
+  (vui-text "Hidden by default, click to reveal."))
+
+(vui-collapsible :title "Details" :initially-expanded t
+  (vui-text "Visible on load."))
+#+end_src
 
 * Hooks
 

--- a/docs/examples/06-collapsible.el
+++ b/docs/examples/06-collapsible.el
@@ -1,0 +1,169 @@
+;;; 06-collapsible.el --- Collapsible Sections Demo -*- lexical-binding: t -*-
+
+;; This file demonstrates the vui-collapsible component:
+;; - Basic collapsible sections
+;; - Multiple independent sections (FAQ style)
+;; - Nested collapsibles
+;; - Controlled mode with parent managing state
+
+;;; Code:
+
+(require 'vui)
+(require 'vui-components)
+
+;;; Basic Collapsible
+
+(vui-defcomponent basic-collapsible-demo ()
+  "Simple collapsible section."
+  :render
+  (vui-vstack
+   (vui-text "Basic Collapsible" :face 'bold)
+   (vui-newline)
+   (vui-collapsible :title "Click to expand"
+     (vui-text "This content is hidden by default.")
+     (vui-text "Click the header to toggle visibility."))))
+
+
+;;; FAQ Style
+
+(vui-defcomponent faq-demo ()
+  "Multiple independent collapsible sections."
+  :render
+  (vui-vstack
+   (vui-text "Frequently Asked Questions" :face 'bold)
+   (vui-newline)
+   (vui-collapsible :title "What is vui.el?" :key 'q1
+     (vui-text "vui.el is a declarative, component-based UI framework")
+     (vui-text "for Emacs, inspired by React and other modern frameworks."))
+   (vui-collapsible :title "How do I install it?" :key 'q2
+     (vui-text "You can install vui.el from MELPA:")
+     (vui-text "  (use-package vui :ensure t)"))
+   (vui-collapsible :title "Is it stable?" :key 'q3
+     (vui-text "Yes! The API is stable and used in real-world projects.")
+     (vui-text "See the README for a list of projects built with vui."))))
+
+
+;;; Nested Collapsibles
+
+(vui-defcomponent nested-collapsible-demo ()
+  "Collapsible sections inside collapsible sections."
+  :render
+  (vui-vstack
+   (vui-text "Nested Sections" :face 'bold)
+   (vui-newline)
+   (vui-collapsible :title "Chapter 1: Getting Started" :key 'ch1
+                    :initially-expanded t
+     (vui-text "Welcome to the documentation!")
+     (vui-collapsible :title "1.1 Installation" :key 'ch1-1
+       (vui-text "Clone the repository...")
+       (vui-text "Add to your load-path..."))
+     (vui-collapsible :title "1.2 Quick Start" :key 'ch1-2
+       (vui-text "Create your first component...")
+       (vui-text "Mount it to a buffer...")))
+   (vui-collapsible :title "Chapter 2: Components" :key 'ch2
+     (vui-text "Components are the building blocks of vui.el.")
+     (vui-collapsible :title "2.1 Defining Components" :key 'ch2-1
+       (vui-text "Use vui-defcomponent to define...")
+       (vui-text "Components accept props and have state..."))
+     (vui-collapsible :title "2.2 Lifecycle Hooks" :key 'ch2-2
+       (vui-text "on-mount, on-update, on-unmount...")
+       (vui-text "Use for side effects and cleanup...")))))
+
+
+;;; Controlled Mode
+
+(vui-defcomponent controlled-collapsible-demo ()
+  "Parent component controls the expanded state."
+  :state ((section1-expanded nil)
+          (section2-expanded nil)
+          (expand-all nil))
+
+  :render
+  (let ((toggle-section1 (lambda (expanded)
+                           (vui-set-state :section1-expanded expanded)))
+        (toggle-section2 (lambda (expanded)
+                           (vui-set-state :section2-expanded expanded)))
+        (toggle-all (lambda ()
+                      (let ((new-state (not expand-all)))
+                        (vui-batch
+                         (vui-set-state :expand-all new-state)
+                         (vui-set-state :section1-expanded new-state)
+                         (vui-set-state :section2-expanded new-state))))))
+    (vui-vstack
+     (vui-text "Controlled Mode" :face 'bold)
+     (vui-text "Parent manages state, enabling bulk operations.")
+     (vui-newline)
+     (vui-button (if expand-all "Collapse All" "Expand All")
+       :on-click toggle-all)
+     (vui-newline)
+     (vui-collapsible :title "Section 1"
+                      :key 'ctrl-s1
+                      :expanded section1-expanded
+                      :on-toggle toggle-section1
+       (vui-text "Content of section 1."))
+     (vui-collapsible :title "Section 2"
+                      :key 'ctrl-s2
+                      :expanded section2-expanded
+                      :on-toggle toggle-section2
+       (vui-text "Content of section 2.")))))
+
+
+;;; Custom Styling
+
+(vui-defcomponent styled-collapsible-demo ()
+  "Collapsible with custom indicators and styling."
+  :render
+  (vui-vstack
+   (vui-text "Custom Styling" :face 'bold)
+   (vui-newline)
+   (vui-collapsible :title "Plus/Minus Style"
+                    :key 'plus-minus
+                    :expanded-indicator "[-]"
+                    :collapsed-indicator "[+]"
+     (vui-text "Using [+] and [-] as indicators."))
+   (vui-collapsible :title "Arrow Style"
+                    :key 'arrow
+                    :expanded-indicator "↓"
+                    :collapsed-indicator "→"
+     (vui-text "Using arrows as indicators."))
+   (vui-collapsible :title "Bold Header"
+                    :key 'bold
+                    :title-face 'bold
+     (vui-text "The header uses a bold face."))
+   (vui-collapsible :title "Extra Indent"
+                    :key 'indent
+                    :indent 4
+                    :initially-expanded t
+     (vui-text "This content has 4 spaces of indent."))))
+
+
+;;; Combined Demo
+
+(vui-defcomponent collapsible-demo ()
+  "Combined demo showing all collapsible features."
+  :render
+  (vui-vstack :spacing 1
+   (vui-text "vui-collapsible Demo" :face '(:weight bold :height 1.2))
+   (vui-text "A togglable section component for vui.el")
+   (vui-newline)
+   (vui-component 'basic-collapsible-demo)
+   (vui-newline)
+   (vui-component 'faq-demo)
+   (vui-newline)
+   (vui-component 'nested-collapsible-demo)
+   (vui-newline)
+   (vui-component 'controlled-collapsible-demo)
+   (vui-newline)
+   (vui-component 'styled-collapsible-demo)))
+
+
+;;; Demo Function
+
+(defun vui-example-collapsible ()
+  "Run the collapsible sections example."
+  (interactive)
+  (vui-mount (vui-component 'collapsible-demo) "*vui-collapsible*"))
+
+
+(provide '06-collapsible)
+;;; 06-collapsible.el ends here

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -1,0 +1,330 @@
+;;; vui-components-test.el --- Tests for vui-components.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Tests for vui-components.el using Buttercup.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+(require 'vui-components)
+
+;; Helper to click buttons (widget.el push-buttons)
+(defun vui-components-test--click-button-at (pos)
+  "Invoke the button widget at POS.
+Buttons are widget.el push-buttons, so we use widget-apply."
+  (let ((widget (widget-at pos)))
+    (when widget
+      (widget-apply widget :action))))
+
+(describe "vui-collapsible"
+  (describe "basic structure"
+    (it "creates a component vnode"
+      (let ((node (vui-collapsible :title "Test"
+                    (vui-text "Content"))))
+        (expect (vui-vnode-component-p node) :to-be-truthy)
+        (expect (vui-vnode-component-type node) :to-equal 'vui-collapsible--internal)))
+
+    (it "passes title prop"
+      (let ((node (vui-collapsible :title "My Section"
+                    (vui-text "Content"))))
+        (expect (plist-get (vui-vnode-component-props node) :title)
+                :to-equal "My Section")))
+
+    (it "passes children"
+      (let ((node (vui-collapsible :title "Section"
+                    (vui-text "Child 1")
+                    (vui-text "Child 2"))))
+        (expect (length (vui-vnode-component-children node)) :to-equal 2))))
+
+  (describe "rendering collapsed state"
+    (it "shows collapsed indicator by default"
+      (vui-defcomponent collapsible-test-1 ()
+        :render
+        (vui-collapsible :title "Section"
+          (vui-text "Hidden content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-1)
+                                  "*test-collapsible-1*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-1*"
+              ;; Should show collapsed indicator
+              (expect (buffer-string) :to-match "▶ Section")
+              ;; Content should NOT be visible
+              (expect (buffer-string) :not :to-match "Hidden content"))
+          (kill-buffer "*test-collapsible-1*"))))
+
+    (it "hides content when collapsed"
+      (vui-defcomponent collapsible-test-2 ()
+        :render
+        (vui-collapsible :title "Test"
+          (vui-text "Secret")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-2)
+                                  "*test-collapsible-2*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-2*"
+              (expect (buffer-string) :not :to-match "Secret"))
+          (kill-buffer "*test-collapsible-2*")))))
+
+  (describe "rendering expanded state"
+    (it "shows expanded indicator when initially-expanded"
+      (vui-defcomponent collapsible-test-3 ()
+        :render
+        (vui-collapsible :title "Section" :initially-expanded t
+          (vui-text "Visible content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-3)
+                                  "*test-collapsible-3*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-3*"
+              ;; Should show expanded indicator
+              (expect (buffer-string) :to-match "▼ Section")
+              ;; Content should be visible
+              (expect (buffer-string) :to-match "Visible content"))
+          (kill-buffer "*test-collapsible-3*"))))
+
+    (it "indents content when expanded"
+      (vui-defcomponent collapsible-test-4 ()
+        :render
+        (vui-collapsible :title "Section" :initially-expanded t
+          (vui-text "Indented")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-4)
+                                  "*test-collapsible-4*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-4*"
+              ;; Content should be on second line with default indent (2 spaces)
+              (goto-char (point-min))
+              (forward-line 1)
+              (expect (looking-at "  Indented") :to-be-truthy))
+          (kill-buffer "*test-collapsible-4*")))))
+
+  (describe "toggle behavior"
+    (it "expands when header is clicked"
+      (vui-defcomponent collapsible-test-5 ()
+        :render
+        (vui-collapsible :title "Clickable"
+          (vui-text "Now visible")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-5)
+                                  "*test-collapsible-5*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-5*"
+              ;; Initially collapsed
+              (expect (buffer-string) :not :to-match "Now visible")
+              ;; Click the header
+              (goto-char (point-min))
+              (vui-components-test--click-button-at (point))
+              ;; Flush deferred render
+              (vui-flush-sync)
+              ;; Now expanded
+              (expect (buffer-string) :to-match "Now visible")
+              (expect (buffer-string) :to-match "▼ Clickable"))
+          (kill-buffer "*test-collapsible-5*"))))
+
+    (it "collapses when header is clicked again"
+      (vui-defcomponent collapsible-test-6 ()
+        :render
+        (vui-collapsible :title "Toggle" :initially-expanded t
+          (vui-text "Content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-6)
+                                  "*test-collapsible-6*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-6*"
+              ;; Initially expanded
+              (expect (buffer-string) :to-match "Content")
+              ;; Click to collapse
+              (goto-char (point-min))
+              (vui-components-test--click-button-at (point))
+              ;; Flush deferred render
+              (vui-flush-sync)
+              ;; Now collapsed
+              (expect (buffer-string) :not :to-match "Content")
+              (expect (buffer-string) :to-match "▶ Toggle"))
+          (kill-buffer "*test-collapsible-6*")))))
+
+  (describe "controlled mode"
+    (it "respects :expanded prop"
+      (vui-defcomponent collapsible-test-7 ()
+        :render
+        (vui-collapsible :title "Controlled" :expanded t
+          (vui-text "Controlled content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-7)
+                                  "*test-collapsible-7*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-7*"
+              (expect (buffer-string) :to-match "Controlled content")
+              (expect (buffer-string) :to-match "▼ Controlled"))
+          (kill-buffer "*test-collapsible-7*"))))
+
+    (it "respects :expanded nil prop"
+      (vui-defcomponent collapsible-test-8 ()
+        :render
+        (vui-collapsible :title "Controlled" :expanded nil
+          (vui-text "Hidden")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-8)
+                                  "*test-collapsible-8*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-8*"
+              (expect (buffer-string) :not :to-match "Hidden")
+              (expect (buffer-string) :to-match "▶ Controlled"))
+          (kill-buffer "*test-collapsible-8*"))))
+
+    (it "calls :on-toggle with new state"
+      (let ((toggled-state nil))
+        (vui-defcomponent collapsible-test-9 ()
+          :render
+          (vui-collapsible :title "Callback"
+                           :on-toggle (lambda (expanded)
+                                        (setq toggled-state expanded))
+            (vui-text "Content")))
+        (let ((instance (vui-mount (vui-component 'collapsible-test-9)
+                                    "*test-collapsible-9*")))
+          (unwind-protect
+              (with-current-buffer "*test-collapsible-9*"
+                ;; Click to expand
+                (goto-char (point-min))
+                (vui-components-test--click-button-at (point))
+                (vui-flush-sync)
+                (expect toggled-state :to-be t)
+                ;; Click to collapse
+                (goto-char (point-min))
+                (vui-components-test--click-button-at (point))
+                (vui-flush-sync)
+                (expect toggled-state :to-be nil))
+            (kill-buffer "*test-collapsible-9*"))))))
+
+  (describe "custom indicators"
+    (it "uses custom expanded indicator"
+      (vui-defcomponent collapsible-test-10 ()
+        :render
+        (vui-collapsible :title "Custom"
+                         :initially-expanded t
+                         :expanded-indicator "[-]"
+          (vui-text "Content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-10)
+                                  "*test-collapsible-10*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-10*"
+              (expect (buffer-string) :to-match "\\[-\\] Custom"))
+          (kill-buffer "*test-collapsible-10*"))))
+
+    (it "uses custom collapsed indicator"
+      (vui-defcomponent collapsible-test-11 ()
+        :render
+        (vui-collapsible :title "Custom"
+                         :collapsed-indicator "[+]"
+          (vui-text "Content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-11)
+                                  "*test-collapsible-11*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-11*"
+              (expect (buffer-string) :to-match "\\[\\+\\] Custom"))
+          (kill-buffer "*test-collapsible-11*")))))
+
+  (describe "custom title-face"
+    (it "applies face to header"
+      (vui-defcomponent collapsible-test-12 ()
+        :render
+        (vui-collapsible :title "Bold" :title-face 'bold
+          (vui-text "Content")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-12)
+                                  "*test-collapsible-12*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-12*"
+              ;; The face is applied via overlay (widget.el uses overlays)
+              (goto-char (point-min))
+              (let* ((ovs (overlays-at (point)))
+                     (face (when ovs (overlay-get (car ovs) 'face))))
+                ;; Face can be 'bold or include 'bold in a list
+                (expect (or (eq face 'bold)
+                            (and (listp face) (memq 'bold face)))
+                        :to-be-truthy)))
+          (kill-buffer "*test-collapsible-12*")))))
+
+  (describe "custom indent"
+    (it "uses custom indent level"
+      (vui-defcomponent collapsible-test-13 ()
+        :render
+        (vui-collapsible :title "Section"
+                         :initially-expanded t
+                         :indent 4
+          (vui-text "Indented")))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-13)
+                                  "*test-collapsible-13*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-13*"
+              ;; Content should be indented 4 spaces
+              (goto-char (point-min))
+              (forward-line 1)
+              (expect (looking-at "    Indented") :to-be-truthy))
+          (kill-buffer "*test-collapsible-13*")))))
+
+  (describe "multiple collapsibles"
+    (it "work independently"
+      (vui-defcomponent collapsible-test-14 ()
+        :render
+        (vui-vstack
+         (vui-collapsible :title "First" :key 'first
+           (vui-text "First content"))
+         (vui-collapsible :title "Second" :key 'second
+           (vui-text "Second content"))))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-14)
+                                  "*test-collapsible-14*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-14*"
+              ;; Both collapsed initially
+              (expect (buffer-string) :not :to-match "First content")
+              (expect (buffer-string) :not :to-match "Second content")
+              ;; Click first header
+              (goto-char (point-min))
+              (vui-components-test--click-button-at (point))
+              (vui-flush-sync)
+              ;; First expanded, second still collapsed
+              (expect (buffer-string) :to-match "First content")
+              (expect (buffer-string) :not :to-match "Second content"))
+          (kill-buffer "*test-collapsible-14*")))))
+
+  (describe "nested collapsibles"
+    (it "work correctly"
+      (vui-defcomponent collapsible-test-15 ()
+        :render
+        (vui-collapsible :title "Outer" :initially-expanded t
+          (vui-collapsible :title "Inner" :key 'inner
+            (vui-text "Deep content"))))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-15)
+                                  "*test-collapsible-15*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-15*"
+              ;; Outer expanded, inner collapsed
+              (expect (buffer-string) :to-match "▼ Outer")
+              (expect (buffer-string) :to-match "▶ Inner")
+              (expect (buffer-string) :not :to-match "Deep content"))
+          (kill-buffer "*test-collapsible-15*"))))
+
+    (it "propagates indentation correctly"
+      (vui-defcomponent collapsible-test-16 ()
+        :render
+        (vui-collapsible :title "Outer" :initially-expanded t
+          (vui-text "Outer content")
+          (vui-collapsible :title "Inner" :initially-expanded t :key 'inner
+            (vui-text "Inner content"))))
+      (let ((instance (vui-mount (vui-component 'collapsible-test-16)
+                                  "*test-collapsible-16*")))
+        (unwind-protect
+            (with-current-buffer "*test-collapsible-16*"
+              ;; Check line by line indentation
+              (goto-char (point-min))
+              ;; Line 1: "▼ Outer" at column 0
+              (expect (looking-at "▼ Outer") :to-be-truthy)
+              (forward-line 1)
+              ;; Line 2: "  Outer content" at column 2
+              (expect (looking-at "  Outer content") :to-be-truthy)
+              (forward-line 1)
+              ;; Line 3: "  ▼ Inner" at column 2
+              (expect (looking-at "  ▼ Inner") :to-be-truthy)
+              (forward-line 1)
+              ;; Line 4: "    Inner content" at column 4 (accumulated indent)
+              (expect (looking-at "    Inner content") :to-be-truthy))
+          (kill-buffer "*test-collapsible-16*"))))))
+
+;;; vui-components-test.el ends here

--- a/vui-components.el
+++ b/vui-components.el
@@ -1,0 +1,158 @@
+;;; vui-components.el --- Component library for vui.el -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+
+;; This file is part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Higher-level components built on vui.el primitives.
+;;
+;; This file provides reusable UI components that compose vui.el's
+;; basic primitives into common patterns.
+;;
+;; Available components:
+;;
+;; - `vui-collapsible' - A togglable section that expands/collapses content
+
+;;; Code:
+
+(require 'vui)
+
+;;; Indentation Context
+
+;; Context to propagate accumulated indentation through nested collapsibles
+(vui-defcontext vui-collapsible-indent 0
+  "Current accumulated indentation level for nested collapsibles.")
+
+;;; Collapsible Component
+
+(vui-defcomponent vui-collapsible--internal
+    (title expanded on-toggle title-face
+     expanded-indicator collapsed-indicator indent initially-expanded)
+  "Internal component for collapsible sections.
+
+TITLE is the header text (required).
+EXPANDED controls the state in controlled mode; :uncontrolled for uncontrolled.
+ON-TOGGLE is called with new expanded state when toggled.
+TITLE-FACE is the face for the header text.
+EXPANDED-INDICATOR is shown when expanded (default \"▼\").
+COLLAPSED-INDICATOR is shown when collapsed (default \"▶\").
+INDENT is the content indentation level (default 2).
+INITIALLY-EXPANDED sets initial state for uncontrolled mode."
+
+  :state ((internal-expanded :unset))
+
+  :render
+  (let* (;; Controlled vs uncontrolled
+         (is-controlled (not (eq expanded :uncontrolled)))
+         ;; For uncontrolled mode, use initially-expanded on first render,
+         ;; then use internal-expanded state for subsequent renders
+         (effective-internal (if (eq internal-expanded :unset)
+                                  initially-expanded
+                                internal-expanded))
+         (is-expanded (if is-controlled expanded effective-internal))
+         ;; Indicators
+         (exp-ind (or expanded-indicator "▼"))
+         (col-ind (or collapsed-indicator "▶"))
+         (indicator (if is-expanded exp-ind col-ind))
+         ;; Indentation: own indent + accumulated from parent
+         (own-indent (or indent 2))
+         (parent-indent (use-vui-collapsible-indent))
+         (total-indent (+ parent-indent own-indent)))
+    (vui-fragment
+     ;; Header - plain clickable text (no indent - inherits from parent)
+     (vui-button (format "%s %s" indicator title)
+       :no-decoration t
+       :face title-face
+       :help-echo nil
+       :on-click (lambda ()
+                   (let ((new-state (not is-expanded)))
+                     (unless is-controlled
+                       (vui-set-state :internal-expanded new-state))
+                     (when on-toggle
+                       (funcall on-toggle new-state)))))
+     ;; Content (indented, only when expanded)
+     ;; Use total-indent directly so nested collapsibles render at correct level
+     ;; Provide accumulated indent to nested collapsibles via context
+     (when is-expanded
+       (vui-fragment
+        (vui-newline)
+        (vui-collapsible-indent-provider total-indent
+          (vui-vstack :indent total-indent
+            children)))))))
+
+;;;###autoload
+(defun vui-collapsible (&rest args)
+  "Create a collapsible section.
+
+ARGS can start with keyword options, followed by children.
+
+Options:
+  :title STRING - header text (required)
+  :expanded BOOL - controlled mode state
+  :on-toggle FN - called with new state on toggle
+  :initially-expanded BOOL - initial state for uncontrolled mode
+  :title-face FACE - face for header
+  :expanded-indicator STRING - shown when expanded (default \"▼\")
+  :collapsed-indicator STRING - shown when collapsed (default \"▶\")
+  :indent N - content indentation (default 2)
+  :key KEY - for reconciliation
+
+Usage:
+  (vui-collapsible :title \"Section\" child1 child2)
+  (vui-collapsible :title \"FAQ\" :initially-expanded t content...)"
+  (let ((title nil)
+        (expanded :uncontrolled)
+        (on-toggle nil)
+        (initially-expanded nil)
+        (title-face nil)
+        (expanded-indicator nil)
+        (collapsed-indicator nil)
+        (indent nil)
+        (key nil)
+        (children nil))
+    ;; Parse keyword arguments
+    (while (and args (keywordp (car args)))
+      (pcase (pop args)
+        (:title (setq title (pop args)))
+        (:expanded (setq expanded (pop args)))
+        (:on-toggle (setq on-toggle (pop args)))
+        (:initially-expanded (setq initially-expanded (pop args)))
+        (:title-face (setq title-face (pop args)))
+        (:expanded-indicator (setq expanded-indicator (pop args)))
+        (:collapsed-indicator (setq collapsed-indicator (pop args)))
+        (:indent (setq indent (pop args)))
+        (:key (setq key (pop args)))))
+    ;; Remaining args are children
+    (setq children (remq nil (flatten-list args)))
+    (vui-component 'vui-collapsible--internal
+      :title title
+      :expanded expanded
+      :on-toggle on-toggle
+      :initially-expanded initially-expanded
+      :title-face title-face
+      :expanded-indicator expanded-indicator
+      :collapsed-indicator collapsed-indicator
+      :indent indent
+      :key key
+      :children children)))
+
+(provide 'vui-components)
+;;; vui-components.el ends here


### PR DESCRIPTION
## Summary

Introduces a new component library (`vui-components.el`) with the first higher-level component: `vui-collapsible` - a togglable section that expands/collapses content.

**Features:**
- Uncontrolled mode (manages own state) and controlled mode (`:expanded` prop)
- Customizable indicators (`:expanded-indicator`, `:collapsed-indicator`), title face, and indentation
- Proper nested indentation via context propagation
- `:on-toggle` callback for state changes
- `:initially-expanded` for default state

**Files added:**
- `vui-components.el` - The component library
- `test/vui-components-test.el` - Comprehensive test suite (16 tests)
- `docs/examples/06-collapsible.el` - Usage examples including FAQ, nested sections, and controlled mode

**Usage:**
```elisp
(require 'vui-components)

;; Basic usage
(vui-collapsible :title "Section"
  (vui-text "Content"))

;; With options
(vui-collapsible :title "Details"
                 :initially-expanded t
                 :title-face 'bold
  (vui-text "Visible by default"))
```