### PR TITLE
feat: add vui-navigable-list component (experimental)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,8 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 - *vui-components.el*: New component library with higher-level components built on vui primitives.
 - =vui-collapsible=: Togglable section that expands/collapses content. Supports both uncontrolled (manages own state) and controlled (=:expanded= prop) modes. Features customizable indicators, title face, indentation, and proper nested indentation via context propagation.
+- =vui-navigable-list=: List component that acts as a single TAB stop with internal arrow key navigation. When users navigate with up/down arrows (or n/p), selection updates and triggers =:on-select=. Supports controlled mode (=:selected= prop), custom rendering (=:render-item=), =:key-fn= for identity comparison, and =:allow-wrap= for boundary wrapping. Best suited for flat, homogeneous lists; for per-item interactivity or nested structure, use =vui-vstack= with individual buttons instead.
+- =vui-button= now accepts =:tab-order= and =:keymap= props. Use =:tab-order -1= to make a button non-tabbable, and =:keymap= to define custom key bindings active when point is on the button.
 
 ** Fixed
 

--- a/docs/examples/07-navigable-list.el
+++ b/docs/examples/07-navigable-list.el
@@ -1,0 +1,149 @@
+;;; 07-navigable-list.el --- Navigable List Demo -*- lexical-binding: t -*-
+
+;; This file demonstrates the vui-navigable-list component:
+;; - Basic navigable list with arrow key navigation
+;; - Two-pane layout (list + detail view)
+;; - Custom rendering with faces
+;; - Controlled vs uncontrolled modes
+
+;;; Code:
+
+(require 'vui)
+(require 'vui-components)
+
+;;; Basic Navigable List
+
+(vui-defcomponent basic-nav-list-demo ()
+  "Simple navigable list."
+  :state ((message ""))
+
+  :render
+  (vui-vstack
+   (vui-text "Basic Navigable List" :face 'bold)
+   (vui-text "Use arrow keys (or n/p) to navigate:")
+   (vui-newline)
+   (vui-navigable-list
+    :items '("First item" "Second item" "Third item" "Fourth item")
+    :on-select (lambda (item)
+                 (vui-set-state :message (format "Selected: %s" item))))
+   (vui-newline)
+   (when (not (string-empty-p message))
+     (vui-text message :face 'success))))
+
+
+;;; Two-Pane Chat Layout
+
+(defvar vui-example-navigable-list--chats
+  '((:id 1 :name "Alice" :messages ("Hey!" "How are you?" "Want to grab coffee?"))
+    (:id 2 :name "Bob" :messages ("Check out this code" "It's amazing"))
+    (:id 3 :name "Carol" :messages ("Meeting at 3pm" "Don't forget!"))
+    (:id 4 :name "David" :messages ("Happy birthday!" "Hope you have a great day")))
+  "Sample chat data for the demo.")
+
+(vui-defcomponent chat-list-demo ()
+  "Two-pane layout: chat list + message view."
+  :state ((selected-chat (car vui-example-navigable-list--chats)))
+
+  :render
+  (vui-vstack
+   (vui-text "Chat Application" :face 'bold)
+   (vui-text "Navigate chats with arrow keys, messages appear on the right")
+   (vui-newline)
+   (vui-hstack :spacing 4
+    ;; Left pane: chat list
+    (vui-vstack
+     (vui-text "Chats" :face 'underline)
+     (vui-navigable-list
+      :items vui-example-navigable-list--chats
+      :selected selected-chat
+      :key-fn (lambda (c) (plist-get c :id))
+      :on-select (lambda (chat)
+                   (vui-set-state :selected-chat chat))
+      :render-item (lambda (chat selected-p)
+                     (let ((name (plist-get chat :name))
+                           (count (length (plist-get chat :messages))))
+                       (if selected-p
+                           (propertize (format "> %s (%d)" name count)
+                                       'face 'highlight)
+                         (format "  %s (%d)" name count))))))
+    ;; Right pane: messages
+    (vui-vstack
+     (vui-text (format "Messages from %s"
+                       (plist-get selected-chat :name))
+               :face 'underline)
+     (vui-list (plist-get selected-chat :messages)
+               (lambda (msg)
+                 (vui-text (format "  %s" msg))))))))
+
+
+;;; Styled Navigable List
+
+(vui-defcomponent styled-nav-list-demo ()
+  "Navigable list with custom rendering and faces."
+  :render
+  (vui-vstack
+   (vui-text "Styled List" :face 'bold)
+   (vui-newline)
+   (vui-navigable-list
+    :items '((:icon "*" :label "Important" :face error)
+             (:icon "!" :label "Warning" :face warning)
+             (:icon "i" :label "Info" :face font-lock-comment-face)
+             (:icon "+" :label "Success" :face success))
+    :key-fn (lambda (item) (plist-get item :label))
+    :render-item (lambda (item selected-p)
+                   (let* ((icon (plist-get item :icon))
+                          (label (plist-get item :label))
+                          (face (plist-get item :face))
+                          (text (format "[%s] %s" icon label)))
+                     (if selected-p
+                         (propertize (concat ">> " text)
+                                     'face (list :inherit face :inverse-video t))
+                       (propertize (concat "   " text) 'face face)))))))
+
+
+;;; Wrapping Navigation
+
+(vui-defcomponent wrapping-nav-list-demo ()
+  "Navigable list that wraps at boundaries."
+  :render
+  (vui-vstack
+   (vui-text "Wrapping Navigation" :face 'bold)
+   (vui-text "Navigation wraps from last to first and vice versa")
+   (vui-newline)
+   (vui-navigable-list
+    :items '("Apple" "Banana" "Cherry")
+    :allow-wrap t
+    :render-item (lambda (item selected-p)
+                   (if selected-p
+                       (format "[%s]" item)
+                     (format " %s " item))))))
+
+
+;;; Combined Demo
+
+(vui-defcomponent navigable-list-demo ()
+  "Combined demo showing all navigable list features."
+  :render
+  (vui-vstack :spacing 1
+   (vui-text "vui-navigable-list Demo" :face '(:weight bold :height 1.2))
+   (vui-text "A list component with arrow key navigation")
+   (vui-newline)
+   (vui-component 'basic-nav-list-demo)
+   (vui-newline)
+   (vui-component 'chat-list-demo)
+   (vui-newline)
+   (vui-component 'styled-nav-list-demo)
+   (vui-newline)
+   (vui-component 'wrapping-nav-list-demo)))
+
+
+;;; Demo Function
+
+(defun vui-example-navigable-list ()
+  "Run the navigable list example."
+  (interactive)
+  (vui-mount (vui-component 'navigable-list-demo) "*vui-navigable-list*"))
+
+
+(provide '07-navigable-list)
+;;; 07-navigable-list.el ends here

--- a/vui-components.el
+++ b/vui-components.el
@@ -30,6 +30,7 @@
 ;; Available components:
 ;;
 ;; - `vui-collapsible' - A togglable section that expands/collapses content
+;; - `vui-navigable-list' - A list with arrow key navigation (single TAB stop)
 
 ;;; Code:
 
@@ -153,6 +154,184 @@ Usage:
       :indent indent
       :key key
       :children children)))
+
+;;; Navigable List Component
+
+(defun vui-navigable-list--make-keymap (len current-index on-navigate allow-wrap
+                                       captured-instance captured-root)
+  "Create keymap for navigable list.
+LEN is the number of items.
+CURRENT-INDEX is the currently selected index.
+ON-NAVIGATE is called with new index when navigation occurs.
+ALLOW-WRAP enables wrapping from last to first and vice versa.
+CAPTURED-INSTANCE and CAPTURED-ROOT are the VUI context for callbacks."
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "<down>")
+      (lambda () (interactive)
+        (let ((new-idx (if (= current-index (1- len))
+                           (if allow-wrap 0 current-index)
+                         (1+ current-index)))
+              (vui--current-instance captured-instance)
+              (vui--root-instance captured-root))
+          (funcall on-navigate new-idx))))
+    (define-key map (kbd "<up>")
+      (lambda () (interactive)
+        (let ((new-idx (if (= current-index 0)
+                           (if allow-wrap (1- len) current-index)
+                         (1- current-index)))
+              (vui--current-instance captured-instance)
+              (vui--root-instance captured-root))
+          (funcall on-navigate new-idx))))
+    (define-key map (kbd "n") (lookup-key map (kbd "<down>")))
+    (define-key map (kbd "p") (lookup-key map (kbd "<up>")))
+    map))
+
+(defun vui-navigable-list--default-render (item selected-p)
+  "Default render function for navigable list items.
+ITEM is the item to render.
+SELECTED-P is non-nil if this item is currently selected."
+  (let ((text (if (stringp item) item (format "%S" item))))
+    (if selected-p
+        (propertize (format "> %s" text) 'face 'highlight)
+      (format "  %s" text))))
+
+(vui-defcomponent vui-navigable-list--internal
+    (items selected on-select render-item key-fn allow-wrap)
+  "Internal component for navigable list.
+
+ITEMS is the list of items to display.
+SELECTED is the selected item (controlled mode) or :uncontrolled.
+ON-SELECT is called with item when selection changes.
+RENDER-ITEM is a function (item selected-p) -> string.
+KEY-FN extracts a key from items for identity comparison.
+ALLOW-WRAP enables wrapping navigation at boundaries."
+
+  :state ((internal-index 0))
+
+  :render
+  (let* ((is-controlled (not (eq selected :uncontrolled)))
+         (key-fn (or key-fn #'identity))
+         (effective-index (if is-controlled
+                              (or (cl-position selected items
+                                               :test (lambda (a b)
+                                                       (equal (funcall key-fn a)
+                                                              (funcall key-fn b))))
+                                  0)
+                            internal-index))
+         (render-fn (or render-item #'vui-navigable-list--default-render))
+         (lines (seq-map-indexed
+                 (lambda (item idx)
+                   (funcall render-fn item (= idx effective-index)))
+                 items))
+         (content (string-join lines "\n"))
+         ;; Capture VUI context for keymap callbacks
+         (captured-instance vui--current-instance)
+         (captured-root vui--root-instance)
+         (on-navigate (lambda (new-index)
+                        (let ((new-item (nth new-index items)))
+                          (unless is-controlled
+                            (vui-set-state :internal-index new-index))
+                          (when on-select
+                            (funcall on-select new-item)))))
+         (nav-keymap (vui-navigable-list--make-keymap
+                      (length items) effective-index on-navigate allow-wrap
+                      captured-instance captured-root)))
+    (if (null items)
+        (vui-text "(empty)" :face 'shadow)
+      (vui-button content
+        :no-decoration t
+        :help-echo nil
+        :keymap nav-keymap))))
+
+;;;###autoload
+(defun vui-navigable-list (&rest args)
+  "Create a navigable list with arrow key navigation.
+
+A list component that acts as a single TAB stop with internal
+arrow key navigation.  When users navigate with up/down arrows
+or n/p keys, selection updates automatically and triggers
+:on-select.
+
+ARGS is a plist of options:
+
+  :items LIST - items to display (required)
+  :selected ITEM - selected item (controlled mode)
+  :on-select FN - called with item on navigation
+  :render-item FN - function (item selected-p) -> string
+  :key-fn FN - extracts key for identity comparison (default #\\='identity)
+  :allow-wrap BOOL - wrap from last→first and first→last
+  :key KEY - for reconciliation
+
+Usage:
+
+  ;; Basic usage (uncontrolled)
+  (vui-navigable-list
+    :items \\='(\"Item 1\" \"Item 2\" \"Item 3\")
+    :on-select (lambda (item) (message \"Selected: %s\" item)))
+
+  ;; Controlled mode with custom rendering
+  (vui-navigable-list
+    :items chats
+    :selected selected-chat
+    :on-select (lambda (chat) (vui-set-state :selected-chat chat))
+    :render-item (lambda (item selected-p)
+                   (if selected-p
+                       (format \"> %s\" (plist-get item :name))
+                     (format \"  %s\" (plist-get item :name))))
+    :key-fn (lambda (item) (plist-get item :id)))
+
+  ;; With wrapping navigation
+  (vui-navigable-list
+    :items items
+    :allow-wrap t
+    :on-select #\\='handle-select)
+
+Implementation Notes:
+
+This component renders all items as a SINGLE multi-line button
+widget with a custom keymap.  This approach provides:
+
+  - Single TAB stop (one widget = one tab stop)
+  - Arrow key navigation via widget.el\\='s :keymap property
+  - Familiar keyboard UX (up/down/n/p to navigate)
+
+Limitations to be aware of:
+
+  - Best suited for flat, homogeneous lists
+  - Cannot have per-item interactive elements (e.g., delete
+    buttons) since items are text within one button widget
+  - Selection is purely visual (text properties), not a
+    separate widget state
+  - The entire list re-renders on each navigation
+
+For lists requiring per-item interactivity or complex nested
+structure, consider using `vui-vstack' with individual
+`vui-button' children and sidebar-level keybindings instead."
+  (let ((items nil)
+        (selected :uncontrolled)
+        (on-select nil)
+        (render-item nil)
+        (key-fn nil)
+        (allow-wrap nil)
+        (key nil))
+    ;; Parse keyword arguments
+    (while (and args (keywordp (car args)))
+      (pcase (pop args)
+        (:items (setq items (pop args)))
+        (:selected (setq selected (pop args)))
+        (:on-select (setq on-select (pop args)))
+        (:render-item (setq render-item (pop args)))
+        (:key-fn (setq key-fn (pop args)))
+        (:allow-wrap (setq allow-wrap (pop args)))
+        (:key (setq key (pop args)))))
+    (vui-component 'vui-navigable-list--internal
+      :items items
+      :selected selected
+      :on-select on-select
+      :render-item render-item
+      :key-fn key-fn
+      :allow-wrap allow-wrap
+      :key key)))
 
 (provide 'vui-components)
 ;;; vui-components.el ends here


### PR DESCRIPTION
## Summary

Add `vui-navigable-list` - a list component that acts as a single TAB stop with internal arrow key navigation. Addresses #9.

### API

```elisp
(vui-navigable-list
  :items '("Item 1" "Item 2" "Item 3")
  :selected selected-item        ; controlled mode
  :on-select #'handle-select     ; called on navigation
  :render-item (lambda (item selected-p) ...)  ; returns string
  :key-fn #'identity             ; for identity comparison
  :allow-wrap t)                 ; wrap at boundaries
```

Also adds `:tab-order` and `:keymap` props to `vui-button`.

### Implementation

Renders all items as a **single multi-line button** with a custom keymap. This provides:
- Single TAB stop (one widget = one stop)
- Arrow key navigation via widget.el's `:keymap` property

## Status: EXPERIMENTAL

**Not yet certain this should be merged as-is.**

### Concerns

1. **`:render-item` returns a string, not a vnode.** This breaks the compositional model - you can't use `vui-text` with faces or nest components:

   ```elisp
   ;; vui-list - compositional (returns vnode)
   (vui-list items (lambda (item) (vui-button item :on-click ...)))

   ;; vui-navigable-list - not compositional (returns string)
   (vui-navigable-list :items items
     :render-item (lambda (item sel) (format "> %s" item)))
   ```

2. **Abstraction leaks.** Users can't add Enter key to activate items, mix in per-item vnodes, or use faces declaratively.

3. **Mental model mismatch.** `vui-list` is a simple mapper. `vui-navigable-list` is a stateful widget pretending to be a list.

### Open Questions

- [ ] **@theschmocker** (from #9): Does this match what you had in mind? Would love your input on the API and whether this solves your use case.

- [ ] Should explore a more idiomatic approach using context to track selection while preserving vnode composition:

   ```elisp
   ;; Hypothetical more idiomatic API
   (vui-list-navigation :items items :selected sel :on-select handler
     (vui-list items
       (lambda (item)
         (vui-list-item item  ; knows if selected via context
           (vui-text (item-name item) :face 'bold)))))
   ```

   This would require deeper widget.el integration for keyboard handling.