### PR TITLE
feat: add :tab-order and :keymap props to vui-button

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -20,6 +20,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 - =vui-quit= command bound to =q=: Quits window when outside widget fields, self-inserts when inside (so you can type "q" in text inputs).
 - =vui-refresh= command bound to =g=: Re-renders the UI with current state when outside widget fields, self-inserts when inside. Applications needing custom refresh logic (e.g., re-fetching data) can override in their derived mode.
+- =vui-button= now accepts =:tab-order= and =:keymap= props. Use =:tab-order -1= to make a button non-tabbable, and =:keymap= to define custom key bindings active when point is on the button.
 
 * v1.0.0 - 2025-12-28
 


### PR DESCRIPTION
## Summary

Add two new optional properties to `vui-button`:

### `:tab-order`

Control TAB navigation order. Set to `-1` to make a button unreachable via TAB.

```elisp
;; This button won't be reached when pressing TAB
(vui-button "Decorative" :tab-order -1 :on-click #'do-something)
```

Useful for:
- Decorative buttons that shouldn't interrupt TAB flow
- Buttons with custom navigation schemes

### `:keymap`

Attach a custom keymap to the button. The keymap is active when point is anywhere on the button widget.

```elisp
(let ((map (make-sparse-keymap)))
  (define-key map (kbd "d") #'delete-item)
  (define-key map (kbd "e") #'edit-item)
  (vui-button item-name :keymap map :on-click #'select-item))
```

Useful for:
- Adding keyboard shortcuts to specific buttons
- Building components with custom navigation (e.g., lists with arrow key navigation)

## Implementation

These props expose standard widget.el capabilities (`:tab-order` and `:keymap` widget properties) through vui's declarative API.