### PR TITLE
feat: add semantic text components

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -11,6 +11,11 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 - *vui-components.el*: New component library with higher-level components built on vui primitives.
 - =vui-collapsible=: Togglable section that expands/collapses content. Supports both uncontrolled (manages own state) and controlled (=:expanded= prop) modes. Features customizable indicators, title face, indentation, and proper nested indentation via context propagation.
+- *Semantic text components*: Thin wrappers around =vui-text= with customizable faces that inherit from standard Emacs faces:
+  - =vui-heading= with =:level= (1-8) and =vui-heading-1= through =vui-heading-8= (inherit from =outline-1= through =outline-8=)
+  - =vui-strong= (inherit from =bold=), =vui-italic= (inherit from =italic=)
+  - =vui-muted= (inherit from =shadow=), =vui-code= (inherit from =fixed-pitch=)
+  - =vui-error= (inherit from =error=), =vui-warning= (inherit from =warning=), =vui-success= (inherit from =success=)
 
 ** Fixed
 

--- a/README.org
+++ b/README.org
@@ -177,6 +177,7 @@ See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:
 - [[file:docs/examples/04-file-browser.el][File Browser]] — Directory navigation with sorting and search
 - [[file:docs/examples/05-wine-tasting.el][Wine Tasting]] — Dynamic tables with interactive cells, computed statistics
 - [[file:docs/examples/06-collapsible.el][Collapsible]] — Expandable/collapsible sections, FAQ style, nested sections
+- [[file:docs/examples/07-semantic-text.el][Semantic Text]] — Headings, emphasis, status messages with customizable faces
 
 * Available Components
 
@@ -217,6 +218,43 @@ See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:
 
 (vui-collapsible :title "Details" :initially-expanded t
   (vui-text "Visible on load."))
+#+end_src
+
+** Semantic Text Components (vui-components.el)
+
+Thin wrappers around =vui-text= with customizable faces:
+
+| Component                       | Inherits From               |
+|---------------------------------+-----------------------------|
+| =vui-heading= / =vui-heading-N= | =outline-1= ... =outline-8= |
+| =vui-strong=                    | =bold=                      |
+| =vui-italic=                    | =italic=                    |
+| =vui-muted=                     | =shadow=                    |
+| =vui-code=                      | =fixed-pitch=               |
+| =vui-error=                     | =error=                     |
+| =vui-warning=                   | =warning=                   |
+| =vui-success=                   | =success=                   |
+
+#+begin_src elisp
+(require 'vui-components)
+
+(vui-vstack
+ (vui-heading-1 "Main Title")
+ (vui-heading-2 "Subsection")
+ (vui-strong "Important!")
+ (vui-muted "Less important...")
+ (vui-code "inline-code")
+ (vui-error "Something went wrong"))
+
+;; Or with :level for programmatic use
+(vui-heading "Dynamic Heading" :level depth)
+#+end_src
+
+Customize faces to fit your theme:
+
+#+begin_src elisp
+(set-face-attribute 'vui-heading-1 nil :height 1.3)
+(set-face-attribute 'vui-muted nil :slant 'italic)
 #+end_src
 
 * Hooks

--- a/docs/examples/07-semantic-text.el
+++ b/docs/examples/07-semantic-text.el
@@ -1,0 +1,139 @@
+;;; 07-semantic-text.el --- Semantic Text Components Demo -*- lexical-binding: t -*-
+
+;; This file demonstrates the semantic text components:
+;; - Headings at different levels
+;; - Text emphasis (strong, italic, muted)
+;; - Inline code
+;; - Status messages (error, warning, success)
+
+;;; Code:
+
+(require 'vui)
+(require 'vui-components)
+
+;;; Headings Demo
+
+(vui-defcomponent headings-demo ()
+  "Demonstrate heading levels."
+  :render
+  (vui-vstack
+   (vui-heading-1 "Heading Level 1")
+   (vui-heading-2 "Heading Level 2")
+   (vui-heading-3 "Heading Level 3")
+   (vui-heading-4 "Heading Level 4")
+   (vui-heading-5 "Heading Level 5")
+   (vui-heading-6 "Heading Level 6")
+   (vui-heading-7 "Heading Level 7")
+   (vui-heading-8 "Heading Level 8")))
+
+
+;;; Emphasis Demo
+
+(vui-defcomponent emphasis-demo ()
+  "Demonstrate text emphasis."
+  :render
+  (vui-vstack
+   (vui-heading-2 "Text Emphasis")
+   (vui-newline)
+   (vui-hstack
+    (vui-text "Normal, ")
+    (vui-strong "strong, ")
+    (vui-italic "italic, ")
+    (vui-muted "muted"))
+   (vui-newline)
+   (vui-text "Use ")
+   (vui-code "vui-code")
+   (vui-text " for inline code snippets.")))
+
+
+;;; Status Messages Demo
+
+(vui-defcomponent status-demo ()
+  "Demonstrate status messages."
+  :render
+  (vui-vstack
+   (vui-heading-2 "Status Messages")
+   (vui-newline)
+   (vui-success "Operation completed successfully!")
+   (vui-warning "Proceed with caution.")
+   (vui-error "Something went wrong.")))
+
+
+;;; Programmatic Headings
+
+(vui-defcomponent programmatic-headings-demo ()
+  "Demonstrate programmatic heading levels with :level prop."
+  :render
+  (vui-vstack
+   (vui-heading-2 "Programmatic Headings")
+   (vui-muted "Using vui-heading with :level for dynamic levels")
+   (vui-newline)
+   (vui-list (number-sequence 1 4)
+             (lambda (n)
+               (vui-heading (format "Level %d heading" n) :level n)))))
+
+
+;;; Document-like Layout
+
+(vui-defcomponent document-demo ()
+  "Demonstrate document-like structure."
+  :render
+  (vui-vstack
+   (vui-heading-1 "Document Title")
+   (vui-muted "A demonstration of semantic text in context")
+   (vui-newline)
+
+   (vui-heading-2 "Introduction")
+   (vui-fragment
+    (vui-text "This is a ")
+    (vui-strong "paragraph")
+    (vui-text " with ")
+    (vui-italic "various")
+    (vui-text " types of emphasis."))
+   (vui-newline)
+
+   (vui-heading-2 "Code Example")
+   (vui-text "Call ")
+   (vui-code "(vui-mount component buffer)")
+   (vui-text " to render.")
+   (vui-newline)
+
+   (vui-heading-2 "Status")
+   (vui-success "All systems operational")
+   (vui-newline)
+
+   (vui-heading-3 "Notes")
+   (vui-muted "Faces can be customized via customize-face or set-face-attribute.")))
+
+
+;;; Combined Demo
+
+(vui-defcomponent semantic-text-demo ()
+  "Combined demo showing all semantic text components."
+  :render
+  (vui-vstack
+   :spacing 1
+   (vui-heading-1 "Semantic Text Components")
+   (vui-muted "Thin wrappers around vui-text with customizable faces")
+   (vui-newline)
+   (vui-component 'headings-demo)
+   (vui-newline)
+   (vui-component 'emphasis-demo)
+   (vui-newline)
+   (vui-component 'status-demo)
+   (vui-newline)
+   (vui-component 'programmatic-headings-demo)
+   (vui-newline)
+   (vui-component 'document-demo)))
+
+
+;;; Demo Function
+
+(defun vui-example-semantic-text ()
+  "Run the semantic text components example."
+  (interactive)
+  (vui-mount (vui-component 'semantic-text-demo) "*vui-semantic-text*"))
+
+
+(provide '07-semantic-text)
+;;; 07-semantic-text.el ends here

--- a/vui-components.el
+++ b/vui-components.el
@@ -30,10 +30,22 @@
 ;; Available components:
 ;;
 ;; - `vui-collapsible' - A togglable section that expands/collapses content
+;;
+;; Semantic text components (thin wrappers around `vui-text'):
+;;
+;; - `vui-heading', `vui-heading-1' ... `vui-heading-8' - Section headings
+;; - `vui-strong' - Bold emphasis
+;; - `vui-italic' - Italic emphasis
+;; - `vui-muted' - De-emphasized text
+;; - `vui-code' - Inline code
+;; - `vui-error' - Error messages
+;; - `vui-warning' - Warning messages
+;; - `vui-success' - Success messages
 
 ;;; Code:
 
 (require 'vui)
+(require 'outline)
 
 ;;; Indentation Context
 
@@ -153,6 +165,143 @@ Usage:
       :indent indent
       :key key
       :children children)))
+
+;;; Semantic Text Faces
+
+(defface vui-heading-1 '((t :inherit outline-1))
+  "Face for level 1 headings."
+  :group 'vui)
+
+(defface vui-heading-2 '((t :inherit outline-2))
+  "Face for level 2 headings."
+  :group 'vui)
+
+(defface vui-heading-3 '((t :inherit outline-3))
+  "Face for level 3 headings."
+  :group 'vui)
+
+(defface vui-heading-4 '((t :inherit outline-4))
+  "Face for level 4 headings."
+  :group 'vui)
+
+(defface vui-heading-5 '((t :inherit outline-5))
+  "Face for level 5 headings."
+  :group 'vui)
+
+(defface vui-heading-6 '((t :inherit outline-6))
+  "Face for level 6 headings."
+  :group 'vui)
+
+(defface vui-heading-7 '((t :inherit outline-7))
+  "Face for level 7 headings."
+  :group 'vui)
+
+(defface vui-heading-8 '((t :inherit outline-8))
+  "Face for level 8 headings."
+  :group 'vui)
+
+(defface vui-strong '((t :inherit bold))
+  "Face for strong/bold emphasis."
+  :group 'vui)
+
+(defface vui-italic '((t :inherit italic))
+  "Face for italic emphasis."
+  :group 'vui)
+
+(defface vui-muted '((t :inherit shadow))
+  "Face for de-emphasized text."
+  :group 'vui)
+
+(defface vui-code '((t :inherit fixed-pitch))
+  "Face for inline code."
+  :group 'vui)
+
+(defface vui-error '((t :inherit error))
+  "Face for error messages."
+  :group 'vui)
+
+(defface vui-warning '((t :inherit warning))
+  "Face for warning messages."
+  :group 'vui)
+
+(defface vui-success '((t :inherit success))
+  "Face for success messages."
+  :group 'vui)
+
+;;; Semantic Text Components
+
+(defconst vui--heading-faces
+  [vui-heading-1 vui-heading-2 vui-heading-3 vui-heading-4
+   vui-heading-5 vui-heading-6 vui-heading-7 vui-heading-8]
+  "Vector of heading faces indexed by level (0-7).")
+
+(defun vui-heading (text &rest props)
+  "Create a heading with TEXT.
+PROPS is a plist accepting :level (1-8, default 1) and :key."
+  (let* ((level (or (plist-get props :level) 1))
+         (key (plist-get props :key))
+         (face (aref vui--heading-faces (1- (max 1 (min 8 level))))))
+    (vui-text text :face face :key key)))
+
+(defun vui-heading-1 (text &optional key)
+  "Create a level 1 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-1 :key key))
+
+(defun vui-heading-2 (text &optional key)
+  "Create a level 2 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-2 :key key))
+
+(defun vui-heading-3 (text &optional key)
+  "Create a level 3 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-3 :key key))
+
+(defun vui-heading-4 (text &optional key)
+  "Create a level 4 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-4 :key key))
+
+(defun vui-heading-5 (text &optional key)
+  "Create a level 5 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-5 :key key))
+
+(defun vui-heading-6 (text &optional key)
+  "Create a level 6 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-6 :key key))
+
+(defun vui-heading-7 (text &optional key)
+  "Create a level 7 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-7 :key key))
+
+(defun vui-heading-8 (text &optional key)
+  "Create a level 8 heading with TEXT and optional KEY."
+  (vui-text text :face 'vui-heading-8 :key key))
+
+(defun vui-strong (text &optional key)
+  "Create bold/strong TEXT with optional KEY."
+  (vui-text text :face 'vui-strong :key key))
+
+(defun vui-italic (text &optional key)
+  "Create italic TEXT with optional KEY."
+  (vui-text text :face 'vui-italic :key key))
+
+(defun vui-muted (text &optional key)
+  "Create de-emphasized TEXT with optional KEY."
+  (vui-text text :face 'vui-muted :key key))
+
+(defun vui-code (text &optional key)
+  "Create inline code TEXT with optional KEY."
+  (vui-text text :face 'vui-code :key key))
+
+(defun vui-error (text &optional key)
+  "Create error message TEXT with optional KEY."
+  (vui-text text :face 'vui-error :key key))
+
+(defun vui-warning (text &optional key)
+  "Create warning message TEXT with optional KEY."
+  (vui-text text :face 'vui-warning :key key))
+
+(defun vui-success (text &optional key)
+  "Create success message TEXT with optional KEY."
+  (vui-text text :face 'vui-success :key key))
 
 (provide 'vui-components)
 ;;; vui-components.el ends here


### PR DESCRIPTION
## Summary

Add thin wrappers around `vui-text` with customizable faces that inherit from standard Emacs faces. Users get sensible defaults but can customize the `vui-*` faces if needed.

Closes #4

## Components

### Headings

```elisp
(vui-heading "Section" :level 1)  ; or :level 2, 3, ... 8
(vui-heading-1 "Main Section")
(vui-heading-2 "Subsection")
;; ... through vui-heading-8
```

Faces inherit from `outline-1` through `outline-8`.

### Emphasis

```elisp
(vui-strong "important")   ; inherits from bold
(vui-italic "emphasized")  ; inherits from italic
(vui-muted "less important")  ; inherits from shadow
(vui-code "inline-code")   ; inherits from fixed-pitch
```

### Status

```elisp
(vui-error "Something went wrong")  ; inherits from error
(vui-warning "Be careful")          ; inherits from warning
(vui-success "Done!")               ; inherits from success
```

## Customization

All faces can be customized:

```elisp
(set-face-attribute 'vui-heading-1 nil :height 1.3)
(set-face-attribute 'vui-success nil :foreground "green")
```