### PR TITLE
feat: add field validation support to vui-field

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,17 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- *Field validation*: =vui-field= now supports built-in validation with new props:
+  - =:valid-regexp= - regexp the value must match
+  - =:valid-p= - custom validation function =(value) -> t/nil=
+  - =:error-face= - face when invalid (default: =vui-field-error=)
+  - =:error-message= - message shown below field when invalid (auto-aligned with field)
+  - Error indicators only appear after the field has been "touched" (modified at least once) for better UX
+- =vui-field-valid-p= function to check field validity by key.
+- =vui-fields-validate= function for form submission: touches all specified fields, returns t if all valid, auto-renders to show errors if any invalid. This is the recommended way to validate on submit.
+- =vui-field-touch= function to mark fields as touched (lower-level primitive).
+- =vui-field-reset= function to clear touched state, useful when resetting forms to pristine state.
+- =vui-field-error= face for styling invalid field input (inherits from =error=).
 - *vui-components.el*: New component library with higher-level components built on vui primitives.
 - =vui-collapsible=: Togglable section that expands/collapses content. Supports both uncontrolled (manages own state) and controlled (=:expanded= prop) modes. Features customizable indicators, title face, indentation, and proper nested indentation via context propagation.
 - *Semantic text components*: Thin wrappers around =vui-text= with customizable faces that inherit from standard Emacs faces:

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -184,21 +184,42 @@ Create a clickable button. By default, buttons render with brackets: =LABEL= bec
 ** vui-field
 
 #+begin_src elisp
-(vui-field &key VALUE SIZE PLACEHOLDER ON-CHANGE ON-SUBMIT KEY FACE SECRET) -> vnode
+(vui-field &key VALUE SIZE PLACEHOLDER ON-CHANGE ON-SUBMIT KEY FACE SECRET
+               VALID-REGEXP VALID-P ERROR-FACE ERROR-MESSAGE) -> vnode
 #+end_src
 
 Create a text input field.
 
-| Property       | Type     | Description                          |
-|----------------+----------+--------------------------------------|
-| =:value=       | string   | Initial content (default "")         |
-| =:size=        | integer  | Width in characters                  |
-| =:placeholder= | string   | Hint text (not yet rendered)         |
-| =:on-change=   | function | Called with value on change          |
-| =:on-submit=   | function | Called with value on RET             |
-| =:key=         | any      | Reconciliation key / lookup key      |
-| =:face=        | symbol   | Text face                            |
-| =:secret=      | boolean  | Hide input (for passwords)           |
+| Property         | Type     | Description                                   |
+|------------------+----------+-----------------------------------------------|
+| =:value=         | string   | Initial content (default "")                  |
+| =:size=          | integer  | Width in characters                           |
+| =:placeholder=   | string   | Hint text (not yet rendered)                  |
+| =:on-change=     | function | Called with value on change                   |
+| =:on-submit=     | function | Called with value on RET                      |
+| =:key=           | any      | Reconciliation key / lookup key               |
+| =:face=          | symbol   | Text face                                     |
+| =:secret=        | boolean  | Hide input (for passwords)                    |
+| =:valid-regexp=  | string   | Regexp the value must match for validation    |
+| =:valid-p=       | function | =(value) -> t/nil= custom validation function |
+| =:error-face=    | face     | Face when invalid (default: =vui-field-error=)  |
+| =:error-message= | string   | Message shown below field when invalid        |
+
+*** Validation
+
+Fields can have built-in validation using =:valid-regexp= and/or =:valid-p=.
+When validation is configured:
+
+- Validation runs on every change (via =:notify=)
+- Error messages only appear after the field has been "touched" (modified at least once)
+- When touched and invalid: =:error-message= (if set) is shown below the field with =:error-face=
+- When valid or pristine (never touched): no error message shown
+- The field itself always renders normally (error-face only applies to the error message)
+- Both =:valid-regexp= and =:valid-p= must pass when both are provided
+
+This "touched" behavior provides better UX - users don't see error messages before they've had a chance to interact with the form.
+
+Use =vui-field-valid-p= to check validity in submit handlers.
 
 #+begin_src elisp
 (vui-field :value name
@@ -210,6 +231,29 @@ Create a text input field.
            :size 20
            :secret t
            :on-change (lambda (v) (vui-set-state :password v)))
+
+;; Email validation with regexp
+(vui-field :key 'email
+           :value email
+           :valid-regexp "^[^@]+@[^@]+\\.[^@]+$"
+           :error-message "Please enter a valid email"
+           :on-change (lambda (v) (vui-set-state :email v)))
+
+;; Password with length validation
+(vui-field :key 'password
+           :value password
+           :secret t
+           :valid-p (lambda (v) (>= (length v) 8))
+           :error-message "Password must be at least 8 characters"
+           :on-change (lambda (v) (vui-set-state :password v)))
+
+;; Combined validation
+(vui-field :key 'username
+           :value username
+           :valid-regexp "^[a-zA-Z0-9_]+$"
+           :valid-p (lambda (v) (>= (length v) 3))
+           :error-message "Username must be 3+ alphanumeric chars"
+           :on-change (lambda (v) (vui-set-state :username v)))
 #+end_src
 
 ** vui-field-value
@@ -225,6 +269,77 @@ Get current value of field with KEY, without triggering re-render.
 (vui-button "Submit"
             :on-click (lambda ()
                         (process (vui-field-value 'my-input))))
+#+end_src
+
+** vui-field-valid-p
+
+#+begin_src elisp
+(vui-field-valid-p KEY) -> t or nil
+#+end_src
+
+Return =t= if field with KEY is valid, =nil= otherwise.
+Returns =nil= if no field with KEY exists.
+
+Use this in submit handlers to check if all fields pass validation before
+proceeding.
+
+** vui-fields-validate
+
+#+begin_src elisp
+(vui-fields-validate &rest KEYS) -> t or nil
+#+end_src
+
+Touch and validate all fields with KEYS. Returns =t= if all fields are valid,
+=nil= otherwise. If any field is invalid, automatically triggers re-render to
+show errors.
+
+This is the recommended way to validate forms on submit:
+
+#+begin_src elisp
+(vui-field :key 'email
+           :value email
+           :valid-regexp "^[^@]+@[^@]+$"
+           :error-message "Invalid email")
+(vui-field :key 'password
+           :value password
+           :valid-p (lambda (v) (>= (length v) 8))
+           :error-message "Min 8 characters")
+(vui-button "Submit"
+            :on-click (lambda ()
+                        (when (vui-fields-validate 'email 'password)
+                          (submit-form))))
+#+end_src
+
+** vui-field-touch
+
+#+begin_src elisp
+(vui-field-touch &rest KEYS)
+#+end_src
+
+Mark field(s) with KEYS as touched/dirty. This causes validation errors to be
+shown on next render. If KEYS is empty, marks ALL fields as touched.
+
+Note: For submit handlers, prefer =vui-fields-validate= which combines touching,
+validation checking, and re-rendering in one call.
+
+** vui-field-reset
+
+#+begin_src elisp
+(vui-field-reset &rest KEYS)
+#+end_src
+
+Clear touched/dirty state for field(s) with KEYS. After reset, validation errors
+won't show until the field is modified again. If KEYS is empty, resets ALL fields.
+
+Use this when resetting a form to pristine state:
+
+#+begin_src elisp
+(vui-button "Reset Form"
+            :on-click (lambda ()
+                        (vui-field-reset)  ; Clear all touched state
+                        (vui-batch
+                          (vui-set-state :name "")
+                          (vui-set-state :email ""))))
 #+end_src
 
 ** vui-checkbox

--- a/test/vui-test.el
+++ b/test/vui-test.el
@@ -253,6 +253,170 @@ Buttons are widget.el push-buttons, so we use widget-apply."
             (expect (vui-field-value 'second-key) :to-equal "second"))
         (kill-buffer "*test-fv4*")))))
 
+(describe "vui-field-valid-p"
+  (it "returns t for valid regexp match"
+    (vui-defcomponent valid-regexp-test ()
+      :render
+      (vui-field :key 'email
+                 :value "test@example.com"
+                 :valid-regexp "^[^@]+@[^@]+$"))
+    (let ((instance (vui-mount (vui-component 'valid-regexp-test) "*test-valid-regexp*")))
+      (unwind-protect
+          (with-current-buffer "*test-valid-regexp*"
+            (expect (vui-field-valid-p 'email) :to-be-truthy))
+        (kill-buffer "*test-valid-regexp*"))))
+
+  (it "returns nil for invalid regexp match"
+    (vui-defcomponent invalid-regexp-test ()
+      :render
+      (vui-field :key 'email
+                 :value "invalid-email"
+                 :valid-regexp "^[^@]+@[^@]+$"))
+    (let ((instance (vui-mount (vui-component 'invalid-regexp-test) "*test-invalid-regexp*")))
+      (unwind-protect
+          (with-current-buffer "*test-invalid-regexp*"
+            (expect (vui-field-valid-p 'email) :to-be nil))
+        (kill-buffer "*test-invalid-regexp*"))))
+
+  (it "returns t for valid-p function returning t"
+    (vui-defcomponent valid-p-test ()
+      :render
+      (vui-field :key 'password
+                 :value "longpassword"
+                 :valid-p (lambda (v) (>= (length v) 8))))
+    (let ((instance (vui-mount (vui-component 'valid-p-test) "*test-valid-p*")))
+      (unwind-protect
+          (with-current-buffer "*test-valid-p*"
+            (expect (vui-field-valid-p 'password) :to-be-truthy))
+        (kill-buffer "*test-valid-p*"))))
+
+  (it "returns nil for valid-p function returning nil"
+    (vui-defcomponent invalid-p-test ()
+      :render
+      (vui-field :key 'password
+                 :value "short"
+                 :valid-p (lambda (v) (>= (length v) 8))))
+    (let ((instance (vui-mount (vui-component 'invalid-p-test) "*test-invalid-p*")))
+      (unwind-protect
+          (with-current-buffer "*test-invalid-p*"
+            (expect (vui-field-valid-p 'password) :to-be nil))
+        (kill-buffer "*test-invalid-p*"))))
+
+  (it "requires both regexp and valid-p to pass"
+    (vui-defcomponent combined-invalid-test ()
+      :render
+      (vui-field :key 'username
+                 :value "ab"
+                 :valid-regexp "^[a-z]+$"
+                 :valid-p (lambda (v) (>= (length v) 3))))
+    (let ((instance (vui-mount (vui-component 'combined-invalid-test) "*test-combined*")))
+      (unwind-protect
+          (with-current-buffer "*test-combined*"
+            ;; "ab" matches regexp but is too short
+            (expect (vui-field-valid-p 'username) :to-be nil))
+        (kill-buffer "*test-combined*"))))
+
+  (it "returns t when both regexp and valid-p pass"
+    (vui-defcomponent combined-valid-test ()
+      :render
+      (vui-field :key 'username
+                 :value "alice"
+                 :valid-regexp "^[a-z]+$"
+                 :valid-p (lambda (v) (>= (length v) 3))))
+    (let ((instance (vui-mount (vui-component 'combined-valid-test) "*test-combined-valid*")))
+      (unwind-protect
+          (with-current-buffer "*test-combined-valid*"
+            (expect (vui-field-valid-p 'username) :to-be-truthy))
+        (kill-buffer "*test-combined-valid*"))))
+
+  (it "returns t for field without validation"
+    (vui-defcomponent no-validation-test ()
+      :render
+      (vui-field :key 'name :value "anything"))
+    (let ((instance (vui-mount (vui-component 'no-validation-test) "*test-no-validation*")))
+      (unwind-protect
+          (with-current-buffer "*test-no-validation*"
+            (expect (vui-field-valid-p 'name) :to-be-truthy))
+        (kill-buffer "*test-no-validation*"))))
+
+  (it "returns nil for non-existent key"
+    (vui-defcomponent exists-test ()
+      :render
+      (vui-field :key 'exists :value "test"))
+    (let ((instance (vui-mount (vui-component 'exists-test) "*test-exists*")))
+      (unwind-protect
+          (with-current-buffer "*test-exists*"
+            (expect (vui-field-valid-p 'nonexistent) :to-be nil))
+        (kill-buffer "*test-exists*"))))
+
+  (it "updates validity when field value changes"
+    (vui-defcomponent update-validity-test ()
+      :render
+      (vui-field :key 'email
+                 :value ""
+                 :valid-regexp "^[^@]+@[^@]+$"))
+    (let ((instance (vui-mount (vui-component 'update-validity-test) "*test-update-validity*")))
+      (unwind-protect
+          (with-current-buffer "*test-update-validity*"
+            (let ((widget (car widget-field-list)))
+              ;; Initially empty, matches nothing, so invalid
+              (expect (vui-field-valid-p 'email) :to-be nil)
+              ;; Type valid email
+              (widget-value-set widget "test@example.com")
+              (widget-apply widget :notify widget)
+              (expect (vui-field-valid-p 'email) :to-be-truthy)
+              ;; Type invalid email
+              (widget-value-set widget "invalid")
+              (widget-apply widget :notify widget)
+              (expect (vui-field-valid-p 'email) :to-be nil)))
+        (kill-buffer "*test-update-validity*"))))
+
+  (it "does not show error message on initial render (pristine field)"
+    (vui-defcomponent error-pristine-test ()
+      :render
+      (vui-field :key 'email
+                 :value "invalid"
+                 :valid-regexp "^[^@]+@[^@]+$"
+                 :error-message "Please enter a valid email"))
+    (let ((instance (vui-mount (vui-component 'error-pristine-test) "*test-error-pristine*")))
+      (unwind-protect
+          (with-current-buffer "*test-error-pristine*"
+            ;; Error should NOT show because field hasn't been touched yet
+            (expect (buffer-string) :not :to-match "Please enter a valid email"))
+        (kill-buffer "*test-error-pristine*"))))
+
+  (it "shows error message after field is touched"
+    (vui-defcomponent error-message-test ()
+      :render
+      (vui-field :key 'email
+                 :value "invalid"
+                 :valid-regexp "^[^@]+@[^@]+$"
+                 :error-message "Please enter a valid email"))
+    (let ((instance (vui-mount (vui-component 'error-message-test) "*test-error-message*")))
+      (unwind-protect
+          (with-current-buffer "*test-error-message*"
+            (let ((widget (car widget-field-list)))
+              ;; Touch the field by triggering notify
+              (widget-value-set widget "still-invalid")
+              (widget-apply widget :notify widget)
+              ;; Now error should show on next render (re-render via on-change would do this)
+              ;; For now just verify dirty state is set
+              (expect (vui--field-dirty-p 'email) :to-be-truthy)))
+        (kill-buffer "*test-error-message*"))))
+
+  (it "does not show error message when valid"
+    (vui-defcomponent no-error-message-test ()
+      :render
+      (vui-field :key 'email
+                 :value "test@example.com"
+                 :valid-regexp "^[^@]+@[^@]+$"
+                 :error-message "Please enter a valid email"))
+    (let ((instance (vui-mount (vui-component 'no-error-message-test) "*test-no-error-message*")))
+      (unwind-protect
+          (with-current-buffer "*test-no-error-message*"
+            (expect (buffer-string) :not :to-match "Please enter a valid email"))
+        (kill-buffer "*test-no-error-message*")))))
+
 (describe "vui-checkbox"
   (it "creates a checkbox vnode"
     (let ((node (vui-checkbox :checked t)))

--- a/vui.el
+++ b/vui.el
@@ -77,6 +77,37 @@ Same options as `vui-lifecycle-error-handler'."
 Stored as (TYPE ERROR CONTEXT) where TYPE is `lifecycle' or `event',
 ERROR is the error object, and CONTEXT is additional information.")
 
+;;; Faces
+
+(defface vui-field-error
+  '((t :inherit error))
+  "Face for invalid field input."
+  :group 'vui)
+
+;;; Field Validation
+
+(defvar-local vui--dirty-fields nil
+  "Set of field keys that have been modified (touched) by the user.
+Used to defer showing validation errors until after first interaction.")
+
+(defun vui--field-dirty-p (key)
+  "Return non-nil if field KEY has been touched/modified by the user."
+  (and key (member key vui--dirty-fields)))
+
+(defun vui--field-mark-dirty (key)
+  "Mark field KEY as touched/modified."
+  (when (and key (not (member key vui--dirty-fields)))
+    (push key vui--dirty-fields)))
+
+(defun vui--field-validate (value valid-regexp valid-p)
+  "Validate VALUE against VALID-REGEXP and VALID-P.
+Returns t if valid, nil if invalid.
+Both checks must pass when provided."
+  (and (or (null valid-regexp)
+           (string-match-p valid-regexp value))
+       (or (null valid-p)
+           (funcall valid-p value))))
+
 ;;; Timing Instrumentation
 
 (defcustom vui-timing-enabled nil
@@ -482,9 +513,13 @@ keybindings while preserving VUI and widget functionality.
   size
   placeholder
   on-change
-  on-submit  ; Called with value when user presses RET
+  on-submit       ; Called with value when user presses RET
   face
-  secret-p)  ; Hide input for passwords
+  secret-p        ; Hide input for passwords
+  valid-regexp    ; Regexp for validation
+  valid-p         ; Function: (value) -> t/nil for validation
+  error-face      ; Face when invalid
+  error-message)  ; Message shown when invalid
 
 ;; Primitive: checkbox
 (cl-defstruct (vui-vnode-checkbox (:include vui-vnode)
@@ -840,21 +875,27 @@ When :keymap is set, this keymap is active when point is on the button."
    :keymap (plist-get props :keymap)
    :key (plist-get props :key)))
 
-(cl-defun vui-field (&key value size placeholder on-change on-submit key face secret)
+(cl-defun vui-field (&key value size placeholder on-change on-submit key face secret
+                          valid-regexp valid-p error-face error-message)
   "Create a field vnode.
 All arguments are keyword-based:
-  :VALUE       - initial field content (defaults to empty string)
-  :SIZE        - field width in characters
-  :PLACEHOLDER - hint text shown when field is empty (not yet rendered)
-  :ON-CHANGE   - called with value on each change (triggers re-render)
-  :ON-SUBMIT   - called with value when user presses RET (no re-render)
-  :KEY         - identifier for `vui-field-value' lookup
-  :FACE        - text face
-  :SECRET      - if non-nil, hide input (for passwords)
+  :VALUE         - initial field content (defaults to empty string)
+  :SIZE          - field width in characters
+  :PLACEHOLDER   - hint text shown when field is empty (not yet rendered)
+  :ON-CHANGE     - called with value on each change (triggers re-render)
+  :ON-SUBMIT     - called with value when user presses RET (no re-render)
+  :KEY           - identifier for `vui-field-value' lookup
+  :FACE          - text face
+  :SECRET        - if non-nil, hide input (for passwords)
+  :VALID-REGEXP  - regexp the value must match for validation
+  :VALID-P       - function (value) -> t/nil for custom validation
+  :ERROR-FACE    - face when invalid (default: `vui-field-error')
+  :ERROR-MESSAGE - message shown below field when invalid
 
 Examples:
   (vui-field :size 20 :key \\='my-input)
-  (vui-field :value \"initial\" :size 20 :on-submit #\\='handle-submit)"
+  (vui-field :value \"initial\" :size 20 :on-submit #\\='handle-submit)
+  (vui-field :value email :valid-regexp \"^[^@]+@[^@]+$\")"
   (vui-vnode-field--create
    :value (or value "")
    :size size
@@ -863,7 +904,11 @@ Examples:
    :on-submit on-submit
    :face face
    :secret-p secret
-   :key key))
+   :key key
+   :valid-regexp valid-regexp
+   :valid-p valid-p
+   :error-face error-face
+   :error-message error-message))
 
 (defun vui-field-value (key)
   "Get the current value of a field identified by KEY.
@@ -881,6 +926,90 @@ Example:
       (when (and (eq (car w) 'editable-field)
                  (eq (widget-get w :vui-key) key))
         (throw 'found (widget-value w))))))
+
+(defun vui-field-valid-p (key)
+  "Return t if field KEY is valid, nil otherwise.
+Returns nil if no field with KEY exists.
+
+Example:
+  (vui-field :key \\='email
+             :value email
+             :valid-regexp \"^[^@]+@[^@]+$\")
+  (vui-button \"Submit\"
+    :on-click (lambda ()
+                (when (vui-field-valid-p \\='email)
+                  ...)))"
+  (catch 'found
+    (dolist (w widget-field-list)
+      (when (and (eq (car w) 'editable-field)
+                 (eq (widget-get w :vui-key) key))
+        (throw 'found (widget-get w :vui-valid))))))
+
+(defun vui-field-touch (&rest keys)
+  "Mark field(s) with KEYS as touched/dirty.
+This causes validation errors to be shown on next render.
+Useful in submit handlers to show all validation errors.
+
+If KEYS is empty, marks ALL fields as touched.
+
+Example:
+  (vui-button \"Submit\"
+    :on-click (lambda ()
+                ;; Mark all fields as touched to show errors
+                (vui-field-touch \\='name \\='email \\='password)
+                (when (and (vui-field-valid-p \\='name)
+                           (vui-field-valid-p \\='email)
+                           (vui-field-valid-p \\='password))
+                  (submit-form))))"
+  (if keys
+      ;; Mark specific fields
+      (dolist (key keys)
+        (vui--field-mark-dirty key))
+    ;; Mark all fields with keys
+    (dolist (w widget-field-list)
+      (when (eq (car w) 'editable-field)
+        (let ((key (widget-get w :vui-key)))
+          (when key
+            (vui--field-mark-dirty key)))))))
+
+(defun vui-field-reset (&rest keys)
+  "Clear touched/dirty state for field(s) with KEYS.
+After reset, validation errors won't show until field is modified again.
+Useful when resetting a form to pristine state.
+
+If KEYS is empty, resets ALL fields.
+
+Example:
+  (vui-button \"Reset Form\"
+    :on-click (lambda ()
+                (vui-field-reset)  ; Clear all touched state
+                (vui-batch
+                  (vui-set-state :name \"\")
+                  (vui-set-state :email \"\"))))"
+  (if keys
+      ;; Reset specific fields
+      (dolist (key keys)
+        (setq vui--dirty-fields (delete key vui--dirty-fields)))
+    ;; Reset all fields
+    (setq vui--dirty-fields nil)))
+
+(defun vui-fields-validate (&rest keys)
+  "Touch and validate all fields with KEYS.
+Returns t if all fields are valid, nil otherwise.
+If any field is invalid, triggers re-render to show errors.
+
+This is the recommended way to validate forms on submit:
+
+Example:
+  (vui-button \"Submit\"
+    :on-click (lambda ()
+                (when (vui-fields-validate \\='name \\='email \\='password)
+                  (submit-form))))"
+  (apply #'vui-field-touch keys)
+  (let ((all-valid (cl-every #'vui-field-valid-p keys)))
+    (unless all-valid
+      (vui-flush-sync))
+    all-valid))
 
 (defun vui-checkbox (&rest props)
   "Create a checkbox vnode.
@@ -2835,6 +2964,17 @@ Handles :truncate and overflow:
            (on-change (vui-vnode-field-on-change vnode))
            (on-submit (vui-vnode-field-on-submit vnode))
            (secret-p (vui-vnode-field-secret-p vnode))
+           (user-face (vui-vnode-field-face vnode))
+           ;; Validation props
+           (valid-regexp (vui-vnode-field-valid-regexp vnode))
+           (valid-p (vui-vnode-field-valid-p vnode))
+           (error-face (or (vui-vnode-field-error-face vnode) 'vui-field-error))
+           (error-message (vui-vnode-field-error-message vnode))
+           ;; Compute validity
+           (is-valid (vui--field-validate value valid-regexp valid-p))
+           ;; Only show errors if field has been touched (dirty)
+           (is-dirty (vui--field-dirty-p field-key))
+           (show-error (and is-dirty (not is-valid)))
            ;; Capture instance context for callback
            (captured-instance vui--current-instance)
            (captured-root vui--root-instance)
@@ -2847,7 +2987,14 @@ Handles :truncate and overflow:
                               :size (or size 20)
                               :value value
                               :secret (when secret-p ?*)
+                              :value-face user-face  ; Always use user face for field content
                               :notify (lambda (widget &rest _)
+                                        ;; Mark field as dirty (touched) on first edit
+                                        (vui--field-mark-dirty field-key)
+                                        ;; Recompute validity and update widget property
+                                        (let* ((new-value (widget-value widget))
+                                               (new-valid (vui--field-validate new-value valid-regexp valid-p)))
+                                          (widget-put widget :vui-valid new-valid))
                                         (when wrapped-change
                                           (let ((vui--current-instance captured-instance)
                                                 (vui--root-instance captured-root))
@@ -2861,7 +3008,23 @@ Handles :truncate and overflow:
         (widget-put w :vui-path captured-path)
         ;; Store key on widget for vui-field-value lookup
         (when field-key
-          (widget-put w :vui-key field-key)))))
+          (widget-put w :vui-key field-key))
+        ;; Store validity on widget
+        (widget-put w :vui-valid is-valid)
+        ;; If field is dirty, invalid, and error-message is set, show error
+        (when (and show-error error-message)
+          ;; Get the column where the field started (for error message alignment)
+          (let ((field-start-col
+                 (save-excursion
+                   (goto-char (widget-field-start w))
+                   (current-column))))
+            (insert "\n")
+            ;; Indent error message to align with field start
+            (when (> field-start-col 0)
+              (insert (make-string field-start-col ?\s)))
+            (let ((start (point)))
+              (insert error-message)
+              (add-text-properties start (point) `(face ,error-face))))))))
 
    ;; Component - reconcile and render
    ((vui-vnode-component-p vnode)


### PR DESCRIPTION
## Summary

- Add built-in validation to `vui-field` with `:valid-regexp`, `:valid-p`, `:error-face`, and `:error-message` props
- Validation errors only appear after field is "touched" (modified) for better UX
- Error messages auto-align with field start column
- New `vui-fields-validate` function for easy form submission handling
- New `vui-field-valid-p`, `vui-field-touch`, `vui-field-reset` functions
- Update 03-forms.el to use new validation API and vui-components

Closes #7