### PR TITLE
fix: preserve button :tab-order and :keymap in table truncation

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 ** Fixed
 
 - Disabled buttons now use =widget-inactive= face instead of the regular button face.
+- Button =:tab-order= and =:keymap= properties are now preserved when buttons are truncated in table cells.
 
 ** Added
 

--- a/vui.el
+++ b/vui.el
@@ -2458,6 +2458,8 @@ Handles :truncate and overflow:
                                :max-width declared-width
                                :no-decoration (vui-vnode-button-no-decoration cell)
                                :help-echo (vui-vnode-button-help-echo cell)
+                               :tab-order (vui-vnode-button-tab-order cell)
+                               :keymap (vui-vnode-button-keymap cell)
                                :key (vui-vnode-key cell))
                             cell))
                          ;; Update path for table cells: (col row ...parent-path...)


### PR DESCRIPTION
When buttons inside table cells needed truncation, they were being reconstructed without copying the `:tab-order` and `:keymap` properties, causing those features to silently stop working.