### PR TITLE
docs: document button :tab-order and :keymap properties

### DIFF
--- a/docs/guide/03-primitives.org
+++ b/docs/guide/03-primitives.org
@@ -99,6 +99,8 @@ Output:
 | =:max-width=     | Maximum width including brackets         |
 | =:no-decoration= | When non-nil, render without brackets    |
 | =:help-echo=     | Tooltip text (nil to disable for perf)   |
+| =:tab-order=     | Tab navigation order (-1 = skip button)  |
+| =:keymap=        | Custom keymap active when on button      |
 | =:key=           | Key for reconciliation                   |
 
 *** Disabled Button

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -161,6 +161,8 @@ Create a clickable button. By default, buttons render with brackets: =LABEL= bec
 | =:max-width=     | integer     | Max width including brackets (truncates)   |
 | =:no-decoration= | boolean     | Render without brackets                    |
 | =:help-echo=     | string/nil  | Tooltip (nil disables for performance)     |
+| =:tab-order=     | integer     | Tab navigation order (-1 = skip)           |
+| =:keymap=        | keymap      | Custom keymap active when on button        |
 | =:key=           | any         | Reconciliation key                         |
 
 #+begin_src elisp


### PR DESCRIPTION
Add missing documentation for `:tab-order` and `:keymap` button properties in the API reference and guide.