### PR TITLE
chore: fix license header in vui-components.el

### DIFF
--- a/vui-components.el
+++ b/vui-components.el
@@ -5,7 +5,7 @@
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
 
-;; This file is part of GNU Emacs.
+;; This file is NOT part of GNU Emacs.
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Change "This file is part of GNU Emacs" to "This file is NOT part of GNU Emacs" for consistency with vui.el.