### PR TITLE
docs: use dynamic year in age-calculator example

### DIFF
--- a/docs/examples/08-typed-fields.el
+++ b/docs/examples/08-typed-fields.el
@@ -18,7 +18,7 @@
 (vui-defcomponent age-calculator ()
   "Calculate age-related statistics."
   :state ((birth-year nil)
-          (current-year 2024))
+          (current-year (decoded-time-year (decode-time))))
 
   :render
   (let* ((age (when (and birth-year current-year)


### PR DESCRIPTION
Replace hardcoded 2024 with `(decoded-time-year (decode-time))` so the example works correctly regardless of when it's run.