### PR TITLE
feat: expand file and directory paths in typed fields

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -16,6 +16,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 - *vui-typed-field component*: New component in =vui-components.el= for typed input with parsing and validation. Uses component state to preserve raw input (e.g., users can see "123f" they typed while error is displayed).
   - Supported types: =integer=, =natnum=, =float=, =number=, =file=, =directory=, =symbol=, =sexp=
+  - Path types (=file=, =directory=) automatically expand =~= and relative paths via =expand-file-name=
   - =:on-change= and =:on-submit= receive typed values only when input is valid
   - =:on-error= callback receives =(error-msg raw-input)= on invalid input
   - Numeric constraints via =:min= and =:max=

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -124,10 +124,25 @@ Buttons are widget.el push-buttons, so we use widget-apply."
         (expect (car result) :to-equal 'ok)
         (expect (cdr result) :to-equal 3.14)))
 
-    (it "parses file path as-is"
-      (let ((result (vui--field-parse-string "/path/to/file" 'file)))
+    (it "expands file path with expand-file-name"
+      (let ((result (vui--field-parse-string "~/test.txt" 'file)))
         (expect (car result) :to-equal 'ok)
-        (expect (cdr result) :to-equal "/path/to/file")))
+        (expect (cdr result) :to-equal (expand-file-name "~/test.txt"))))
+
+    (it "expands directory path with expand-file-name"
+      (let ((result (vui--field-parse-string "~/Documents" 'directory)))
+        (expect (car result) :to-equal 'ok)
+        (expect (cdr result) :to-equal (expand-file-name "~/Documents"))))
+
+    (it "returns nil for empty file path"
+      (let ((result (vui--field-parse-string "" 'file)))
+        (expect (car result) :to-equal 'ok)
+        (expect (cdr result) :to-be nil)))
+
+    (it "returns nil for empty directory path"
+      (let ((result (vui--field-parse-string "  " 'directory)))
+        (expect (car result) :to-equal 'ok)
+        (expect (cdr result) :to-be nil)))
 
     (it "parses symbol"
       (let ((result (vui--field-parse-string "my-symbol" 'symbol)))

--- a/vui-components.el
+++ b/vui-components.el
@@ -123,7 +123,9 @@ When TYPE is nil, returns (ok . STRING) unchanged."
                (cons 'ok (string-to-number trimmed)))
               (t (cons 'error "Not a valid number"))))
             ((or 'file 'directory)
-             (cons 'ok string))
+             (if (string-empty-p trimmed)
+                 (cons 'ok nil)
+               (cons 'ok (expand-file-name trimmed))))
             ('symbol
              (if (string-empty-p trimmed)
                  (cons 'error "Symbol name cannot be empty")


### PR DESCRIPTION
## Summary
- Expand `~` and relative paths using `expand-file-name` for file/directory typed fields
- Enables validation checks like `:must-exist` to work correctly with user-friendly paths