### PR TITLE
feat: add :must-exist validation for file/directory fields

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -17,6 +17,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 - *vui-typed-field component*: New component in =vui-components.el= for typed input with parsing and validation. Uses component state to preserve raw input (e.g., users can see "123f" they typed while error is displayed).
   - Supported types: =integer=, =natnum=, =float=, =number=, =file=, =directory=, =symbol=, =sexp=
   - Path types (=file=, =directory=) automatically expand =~= and relative paths via =expand-file-name=
+  - =:must-exist= constraint for =file= and =directory= types (validates path existence)
   - =:on-change= and =:on-submit= receive typed values only when input is valid
   - =:on-error= callback receives =(error-msg raw-input)= on invalid input
   - Numeric constraints via =:min= and =:max=

--- a/docs/examples/08-typed-fields.el
+++ b/docs/examples/08-typed-fields.el
@@ -277,12 +277,14 @@
        :on-change (lambda (expr) (funcall update :features expr))))
      (vui-text "  (a list of symbols)" :face 'shadow)
 
-     ;; Data directory (file path)
+     ;; Data directory (file path with existence check)
      (vui-hstack
       (vui-text "Data Dir: ")
       (vui-directory-field
        :value (plist-get config :data-dir)
        :size 30
+       :must-exist t
+       :show-error 'inline
        :on-change (lambda (path) (funcall update :data-dir path))))
 
      ;; Preview

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -165,19 +165,19 @@ Buttons are widget.el push-buttons, so we use widget-apply."
 
   (describe "vui--typed-field-validate"
     (it "validates :min constraint"
-      (let ((err (vui--typed-field-validate 5 'integer 10 nil nil nil "5")))
+      (let ((err (vui--typed-field-validate 5 'integer 10 nil nil nil nil "5")))
         (expect err :to-match "at least 10")))
 
     (it "validates :max constraint"
-      (let ((err (vui--typed-field-validate 100 'integer nil 50 nil nil "100")))
+      (let ((err (vui--typed-field-validate 100 'integer nil 50 nil nil nil "100")))
         (expect err :to-match "at most 50")))
 
     (it "validates :required constraint"
-      (let ((err (vui--typed-field-validate nil 'integer nil nil nil t "  ")))
+      (let ((err (vui--typed-field-validate nil 'integer nil nil nil t nil "  ")))
         (expect err :to-match "required")))
 
     (it "passes when constraints are met"
-      (let ((err (vui--typed-field-validate 25 'integer 10 50 nil nil "25")))
+      (let ((err (vui--typed-field-validate 25 'integer 10 50 nil nil nil "25")))
         (expect err :to-be nil)))
 
     (it "calls custom validator with typed value"
@@ -185,9 +185,33 @@ Buttons are widget.el push-buttons, so we use widget-apply."
              (validator (lambda (v)
                           (setq received-value v)
                           (when (cl-oddp v) "Must be even")))
-             (err (vui--typed-field-validate 5 'integer nil nil validator nil "5")))
+             (err (vui--typed-field-validate 5 'integer nil nil validator nil nil "5")))
         (expect received-value :to-equal 5)
-        (expect err :to-equal "Must be even")))))
+        (expect err :to-equal "Must be even")))
+
+    (it "validates :must-exist for file type"
+      (let ((err (vui--typed-field-validate "/nonexistent/file.txt" 'file
+                                             nil nil nil nil t "/nonexistent/file.txt")))
+        (expect err :to-match "File does not exist")))
+
+    (it "validates :must-exist for directory type"
+      (let ((err (vui--typed-field-validate "/nonexistent/dir" 'directory
+                                             nil nil nil nil t "/nonexistent/dir")))
+        (expect err :to-match "Directory does not exist")))
+
+    (it "passes :must-exist when file exists"
+      (let ((err (vui--typed-field-validate (expand-file-name "vui.el") 'file
+                                             nil nil nil nil t "vui.el")))
+        (expect err :to-be nil)))
+
+    (it "passes :must-exist when directory exists"
+      (let ((err (vui--typed-field-validate (expand-file-name "test") 'directory
+                                             nil nil nil nil t "test")))
+        (expect err :to-be nil)))
+
+    (it "skips :must-exist check for nil value"
+      (let ((err (vui--typed-field-validate nil 'file nil nil nil nil t "")))
+        (expect err :to-be nil)))))
 
 (describe "vui-collapsible"
   (describe "basic structure"


### PR DESCRIPTION
## Summary
- Add `:must-exist` prop to validate that file/directory paths exist
- For file type: checks `file-exists-p`
- For directory type: checks `file-directory-p`