### PR TITLE
feat: add :extensions validation for file type

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -18,6 +18,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   - Supported types: =integer=, =natnum=, =float=, =number=, =file=, =directory=, =symbol=, =sexp=
   - Path types (=file=, =directory=) automatically expand =~= and relative paths via =expand-file-name=
   - =:must-exist= constraint for =file= and =directory= types (validates path existence)
+  - =:extensions= constraint for =file= type (e.g., =:extensions '("el" "org")=)
   - =:on-change= and =:on-submit= receive typed values only when input is valid
   - =:on-error= callback receives =(error-msg raw-input)= on invalid input
   - Numeric constraints via =:min= and =:max=

--- a/docs/examples/08-typed-fields.el
+++ b/docs/examples/08-typed-fields.el
@@ -223,7 +223,8 @@
                     :port 8080
                     :timeout 30.0
                     :features (logging metrics)
-                    :data-dir "/var/data")))
+                    :data-dir "/var/data"
+                    :config-file "~/.config/app.el")))
 
   :render
   (let ((update (lambda (key val)
@@ -286,6 +287,16 @@
        :must-exist t
        :show-error 'inline
        :on-change (lambda (path) (funcall update :data-dir path))))
+
+     ;; Config file (file path with extension validation)
+     (vui-hstack
+      (vui-text "Config:   ")
+      (vui-file-field
+       :value (plist-get config :config-file)
+       :size 30
+       :extensions '("el" "json" "yaml")
+       :show-error 'inline
+       :on-change (lambda (path) (funcall update :config-file path))))
 
      ;; Preview
      (vui-newline)

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -165,19 +165,19 @@ Buttons are widget.el push-buttons, so we use widget-apply."
 
   (describe "vui--typed-field-validate"
     (it "validates :min constraint"
-      (let ((err (vui--typed-field-validate 5 'integer 10 nil nil nil nil "5")))
+      (let ((err (vui--typed-field-validate 5 'integer 10 nil nil nil nil nil "5")))
         (expect err :to-match "at least 10")))
 
     (it "validates :max constraint"
-      (let ((err (vui--typed-field-validate 100 'integer nil 50 nil nil nil "100")))
+      (let ((err (vui--typed-field-validate 100 'integer nil 50 nil nil nil nil "100")))
         (expect err :to-match "at most 50")))
 
     (it "validates :required constraint"
-      (let ((err (vui--typed-field-validate nil 'integer nil nil nil t nil "  ")))
+      (let ((err (vui--typed-field-validate nil 'integer nil nil nil t nil nil "  ")))
         (expect err :to-match "required")))
 
     (it "passes when constraints are met"
-      (let ((err (vui--typed-field-validate 25 'integer 10 50 nil nil nil "25")))
+      (let ((err (vui--typed-field-validate 25 'integer 10 50 nil nil nil nil "25")))
         (expect err :to-be nil)))
 
     (it "calls custom validator with typed value"
@@ -185,32 +185,46 @@ Buttons are widget.el push-buttons, so we use widget-apply."
              (validator (lambda (v)
                           (setq received-value v)
                           (when (cl-oddp v) "Must be even")))
-             (err (vui--typed-field-validate 5 'integer nil nil validator nil nil "5")))
+             (err (vui--typed-field-validate 5 'integer nil nil validator nil nil nil "5")))
         (expect received-value :to-equal 5)
         (expect err :to-equal "Must be even")))
 
     (it "validates :must-exist for file type"
       (let ((err (vui--typed-field-validate "/nonexistent/file.txt" 'file
-                                             nil nil nil nil t "/nonexistent/file.txt")))
+                                             nil nil nil nil t nil "/nonexistent/file.txt")))
         (expect err :to-match "File does not exist")))
 
     (it "validates :must-exist for directory type"
       (let ((err (vui--typed-field-validate "/nonexistent/dir" 'directory
-                                             nil nil nil nil t "/nonexistent/dir")))
+                                             nil nil nil nil t nil "/nonexistent/dir")))
         (expect err :to-match "Directory does not exist")))
 
     (it "passes :must-exist when file exists"
       (let ((err (vui--typed-field-validate (expand-file-name "vui.el") 'file
-                                             nil nil nil nil t "vui.el")))
+                                             nil nil nil nil t nil "vui.el")))
         (expect err :to-be nil)))
 
     (it "passes :must-exist when directory exists"
       (let ((err (vui--typed-field-validate (expand-file-name "test") 'directory
-                                             nil nil nil nil t "test")))
+                                             nil nil nil nil t nil "test")))
         (expect err :to-be nil)))
 
     (it "skips :must-exist check for nil value"
-      (let ((err (vui--typed-field-validate nil 'file nil nil nil nil t "")))
+      (let ((err (vui--typed-field-validate nil 'file nil nil nil nil t nil "")))
+        (expect err :to-be nil)))
+
+    (it "validates :extensions for file type"
+      (let ((err (vui--typed-field-validate "/path/to/file.txt" 'file
+                                             nil nil nil nil nil '("el" "org") "/path/to/file.txt")))
+        (expect err :to-match "Must be a .el or .org file")))
+
+    (it "passes :extensions when extension matches"
+      (let ((err (vui--typed-field-validate "/path/to/file.el" 'file
+                                             nil nil nil nil nil '("el" "org") "/path/to/file.el")))
+        (expect err :to-be nil)))
+
+    (it "skips :extensions check for nil value"
+      (let ((err (vui--typed-field-validate nil 'file nil nil nil nil nil '("el") "")))
         (expect err :to-be nil)))))
 
 (describe "vui-collapsible"


### PR DESCRIPTION
## Summary
- Add `:extensions` prop to validate file extensions
- Accepts a list of allowed extensions, e.g., `'("el" "org")`
- Shows helpful error message like "Must be a .el or .org file"