### PR TITLE
feat: add vui-rerender and vui-update for instance management

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -14,6 +14,9 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- *Instance update API*: New public functions for re-rendering mounted instances:
+  - =vui-rerender= - Re-render an instance preserving component state and memos. Useful for forcing a redraw.
+  - =vui-update= - Update instance props, invalidate all memos, and re-render. Useful when new data arrives and computed values need to refresh while preserving UI state (like collapsed sections).
 - *vui-typed-field component*: New component in =vui-components.el= for typed input with parsing and validation. Uses component state to preserve raw input (e.g., users can see "123f" they typed while error is displayed).
   - Supported types: =integer=, =natnum=, =float=, =number=, =file=, =directory=, =symbol=, =sexp=
   - Path types (=file=, =directory=) automatically expand =~= and relative paths via =expand-file-name=

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -91,6 +91,54 @@ Mount a component as root and render to a buffer.
 (vui-mount (vui-component 'my-app :title "Hello") "*my-app*")
 #+end_src
 
+** vui-rerender
+
+#+begin_src elisp
+(vui-rerender INSTANCE) -> instance
+#+end_src
+
+Re-render an existing instance, preserving component state.
+
+Triggers a re-render of the component tree rooted at INSTANCE. Component state
+(including collapsed sections, internal state) is preserved through
+reconciliation. Memoized values are also preserved and will only recompute if
+their dependencies change.
+
+Returns INSTANCE for chaining.
+
+#+begin_src elisp
+;; Re-render without changing anything (useful for forcing a redraw)
+(vui-rerender instance)
+#+end_src
+
+** vui-update
+
+#+begin_src elisp
+(vui-update INSTANCE NEW-PROPS) -> instance
+#+end_src
+
+Update instance props, invalidate memos, and re-render.
+
+This is useful when new data arrives and you want computed values to refresh
+while preserving UI state (like collapsed sections).
+
+NEW-PROPS completely replaces the instance's current props. All memoized values
+in the instance tree are invalidated, forcing recomputation on the next render.
+Component state is preserved through reconciliation.
+
+Returns INSTANCE for chaining.
+
+#+begin_src elisp
+;; Update with new data - memos recompute, but collapse state preserved
+(if existing-instance
+    (vui-update existing-instance (list :note new-note))
+  (vui-mount (vui-component 'my-sidebar :note new-note) "*sidebar*"))
+#+end_src
+
+*Difference from vui-rerender:*
+- =vui-rerender= - preserves memos (deps-based caching works normally)
+- =vui-update= - invalidates all memos (forces recomputation)
+
 * Primitives
 
 Interactive primitives (buttons, fields, checkboxes, selects) support =TAB= /


### PR DESCRIPTION
## Summary

- Add `vui-rerender` - Re-render an instance preserving component state and memos
- Add `vui-update` - Update instance props, invalidate all memos, and re-render

## Motivation

Applications like vulpea-ui need to refresh content (e.g., sidebar stats on idle/save) while preserving user interactions (like collapsed sections). Previously the only option was `vui-mount` which creates a fresh instance tree, losing all state.

## API

```elisp
;; Just redraw, preserve everything
(vui-rerender instance)

;; Update props and refresh computed values, preserve UI state
(vui-update instance (list :note new-note))
```

The distinction:
- `vui-rerender` = "redraw with current state" (memos preserved)
- `vui-update` = "new data arrived, refresh everything" (memos cleared)

Both return the instance for chaining.

Closes #35