### PR TITLE
fix: schedule deferred re-renders per root instance

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- Deferred re-renders now use a per-instance timer instead of a single global one. Previously, state updates in two VUI buffers within the same =vui-render-delay= window cancelled each other's pending render, silently leaving the first buffer stale. =vui-flush-sync= likewise no longer cancels pending renders that belong to other buffers.
 - Disabled buttons now use =widget-inactive= face instead of the regular button face.
 - Button =:tab-order= and =:keymap= properties are now preserved when buttons are truncated in table cells.
 

--- a/test/vui-state-test.el
+++ b/test/vui-state-test.el
@@ -189,6 +189,62 @@
                       :to-equal "42"))
           (kill-buffer "*test-flush*"))))))
 
+(describe "deferred rendering across buffers"
+  (it "does not cancel pending renders in other buffers"
+    (let ((vui-render-delay 0.01))
+      (vui-defcomponent multi-buffer-tick (name)
+        :state ((n 0))
+        :render (vui-text (format "%s:%d" name n)))
+      (let ((instance-a (vui-mount (vui-component 'multi-buffer-tick :name "A")
+                                   "*test-defer-a*"))
+            (instance-b (vui-mount (vui-component 'multi-buffer-tick :name "B")
+                                   "*test-defer-b*")))
+        (unwind-protect
+            (progn
+              ;; Update both buffers within the same delay window
+              (with-current-buffer "*test-defer-a*"
+                (let ((vui--current-instance instance-a))
+                  (vui-set-state :n 1)))
+              (with-current-buffer "*test-defer-b*"
+                (let ((vui--current-instance instance-b))
+                  (vui-set-state :n 1)))
+              ;; Let both timers fire
+              (sleep-for 0.05)
+              (expect (with-current-buffer "*test-defer-a*" (buffer-string))
+                      :to-equal "A:1")
+              (expect (with-current-buffer "*test-defer-b*" (buffer-string))
+                      :to-equal "B:1"))
+          (kill-buffer "*test-defer-a*")
+          (kill-buffer "*test-defer-b*")))))
+
+  (it "flush-sync does not cancel pending renders in other buffers"
+    (let ((vui-render-delay 0.01))
+      (vui-defcomponent flush-other-tick (name)
+        :state ((n 0))
+        :render (vui-text (format "%s:%d" name n)))
+      (let ((instance-a (vui-mount (vui-component 'flush-other-tick :name "A")
+                                   "*test-flush-a*"))
+            (instance-b (vui-mount (vui-component 'flush-other-tick :name "B")
+                                   "*test-flush-b*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer "*test-flush-a*"
+                (let ((vui--current-instance instance-a))
+                  (vui-set-state :n 1)))
+              (with-current-buffer "*test-flush-b*"
+                (let ((vui--current-instance instance-b))
+                  (vui-set-state :n 1)))
+              ;; Flush A synchronously; B's pending render must survive
+              (with-current-buffer "*test-flush-a*"
+                (vui-flush-sync))
+              (expect (with-current-buffer "*test-flush-a*" (buffer-string))
+                      :to-equal "A:1")
+              (sleep-for 0.05)
+              (expect (with-current-buffer "*test-flush-b*" (buffer-string))
+                      :to-equal "B:1"))
+          (kill-buffer "*test-flush-a*")
+          (kill-buffer "*test-flush-b*"))))))
+
 (describe "should-update"
   (it "always renders on first render"
     (let ((vui-render-delay nil)

--- a/vui.el
+++ b/vui.el
@@ -619,7 +619,8 @@ parsing and validation, use `vui-typed-field' from vui-components.el."
   memos       ; Hash table of memo-id -> (deps . value) for let-memo
   asyncs      ; Hash table of async-id -> (key status data error timer) for vui-use-async
   prev-props  ; Props from previous render (for on-update)
-  prev-state) ; State from previous render (for on-update)
+  prev-state  ; State from previous render (for on-update)
+  render-timer) ; Pending deferred-render timer (only used on root instances)
 
 ;; Registry of component definitions
 (defvar vui--component-registry (make-hash-table :test 'eq)
@@ -1152,9 +1153,6 @@ PROPS-AND-CHILDREN is a plist of props, optionally ending with :children."
 (defvar vui--render-pending-p nil
   "Non-nil if a re-render is pending (during batched updates).")
 
-(defvar vui--render-timer nil
-  "Timer for deferred rendering.")
-
 (defcustom vui-render-delay 0.01
   "Seconds to wait before rendering when using deferred rendering.
 This delay allows multiple state changes to be batched into a single
@@ -1315,18 +1313,25 @@ Otherwise, render immediately or after delay based on config."
   "Schedule a deferred render using current context."
   (vui--schedule-deferred-render-for (vui--get-root-instance)))
 
+(defun vui--cancel-render-timer (root)
+  "Cancel ROOT's pending deferred-render timer, if any."
+  (when-let* ((timer (vui-instance-render-timer root)))
+    (cancel-timer timer)
+    (setf (vui-instance-render-timer root) nil)))
+
 (defun vui--schedule-deferred-render-for (root)
   "Schedule a render of ROOT after a short delay.
 Uses a regular timer so the render fires reliably regardless of
-whether Emacs is idle."
+whether Emacs is idle.  The timer is stored on ROOT itself, so each
+mounted root has its own schedule and re-scheduling one root never
+cancels another root's pending render."
   (when root
-    (when vui--render-timer
-      (cancel-timer vui--render-timer))
-    (setq vui--render-timer
+    (vui--cancel-render-timer root)
+    (setf (vui-instance-render-timer root)
           (run-with-timer
            vui-render-delay nil
            (lambda ()
-             (setq vui--render-timer nil)
+             (setf (vui-instance-render-timer root) nil)
              (vui--rerender-instance root))))))
 
 (defmacro vui-batch (&rest body)
@@ -1357,12 +1362,11 @@ Example:
          (vui--rerender-instance vui--batch-root))))))
 
 (defun vui-flush-sync ()
-  "Force immediate re-render, bypassing any pending timers.
-Use when you need the UI to update synchronously."
-  (when vui--render-timer
-    (cancel-timer vui--render-timer)
-    (setq vui--render-timer nil))
+  "Force immediate re-render of the current root, bypassing its pending timer.
+Use when you need the UI to update synchronously.  Pending renders
+scheduled for other roots (other buffers) are not affected."
   (when vui--root-instance
+    (vui--cancel-render-timer vui--root-instance)
     (vui--rerender-instance vui--root-instance)))
 
 ;;; Effects System


### PR DESCRIPTION
A single global timer meant that scheduling a deferred render for one
root cancelled any pending render for another root. With two mounted
VUI apps, state updates landing within the same vui-render-delay
window silently dropped the first buffer's re-render, leaving its UI
stale. vui-flush-sync had the same flaw: it cancelled whichever
buffer's render happened to be pending and only flushed the current
one.

Store the pending timer on the root instance itself so every mounted
app has an independent render schedule.

