### PR TITLE
feat: add vui-get-instance to access root instance from buffer

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-get-instance= - Return the root instance mounted in a buffer (defaults to the current buffer). Lets applications drive a mounted UI via =vui-rerender= / =vui-update= / =vui-update-props= without maintaining their own buffer-to-instance storage (#36).
 - *Instance update API*: New public functions for re-rendering mounted instances:
   - =vui-rerender= - Re-render an instance preserving component state and memos. Useful for forcing a redraw.
   - =vui-update= - Update instance props, invalidate all memos, and re-render. Useful when new data arrives and computed values need to refresh while preserving UI state (like collapsed sections).

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -91,6 +91,26 @@ Mount a component as root and render to a buffer.
 (vui-mount (vui-component 'my-app :title "Hello") "*my-app*")
 #+end_src
 
+** vui-get-instance
+
+#+begin_src elisp
+(vui-get-instance &optional BUFFER) -> instance or nil
+#+end_src
+
+Return the root component instance mounted in BUFFER.
+
+- BUFFER :: Buffer object or buffer name (default: current buffer)
+- Returns :: The root instance, or nil if BUFFER does not exist or has no
+  mounted VUI instance
+
+Use this together with =vui-rerender=, =vui-update=, and =vui-update-props=
+to drive a mounted UI from outside, without storing the instance yourself:
+
+#+begin_src elisp
+(when-let* ((instance (vui-get-instance "*sidebar*")))
+  (vui-update instance (list :note note)))
+#+end_src
+
 ** vui-rerender
 
 #+begin_src elisp

--- a/test/vui-test.el
+++ b/test/vui-test.el
@@ -397,6 +397,35 @@ Buttons are widget.el push-buttons, so we use widget-apply."
           (widget-apply widget :notify widget))
         (expect new-value :to-equal "changed")))))
 
+(describe "vui-get-instance"
+  (it "returns the root instance mounted in a buffer"
+    (vui-defcomponent get-instance-test ()
+      :render (vui-text "hi"))
+    (let ((instance (vui-mount (vui-component 'get-instance-test)
+                               "*test-get-instance*")))
+      (unwind-protect
+          (progn
+            ;; By buffer name
+            (expect (vui-get-instance "*test-get-instance*") :to-be instance)
+            ;; By buffer object
+            (expect (vui-get-instance (get-buffer "*test-get-instance*"))
+                    :to-be instance)
+            ;; Defaults to current buffer
+            (with-current-buffer "*test-get-instance*"
+              (expect (vui-get-instance) :to-be instance)))
+        (kill-buffer "*test-get-instance*"))))
+
+  (it "returns nil when buffer has no mounted instance"
+    (with-temp-buffer
+      (expect (vui-get-instance) :to-be nil))
+    (let ((buf (get-buffer-create "*test-no-instance*")))
+      (unwind-protect
+          (expect (vui-get-instance buf) :to-be nil)
+        (kill-buffer buf))))
+
+  (it "returns nil for a nonexistent buffer name"
+    (expect (vui-get-instance "*test-does-not-exist*") :to-be nil)))
+
 (describe "vui-mode keymap"
   (describe "keymap hierarchy"
     (it "inherits special-mode-map bindings"

--- a/vui.el
+++ b/vui.el
@@ -3067,5 +3067,20 @@ Returns the root instance."
     (switch-to-buffer buf)
     instance))
 
+(defun vui-get-instance (&optional buffer)
+  "Return the root component instance mounted in BUFFER.
+BUFFER defaults to the current buffer and may be a buffer object or
+a buffer name.  Returns nil if BUFFER does not exist or has no
+mounted VUI instance.
+
+Use this together with `vui-rerender', `vui-update', and
+`vui-update-props' to drive a mounted UI from outside:
+
+  (when-let* ((instance (vui-get-instance \"*sidebar*\")))
+    (vui-update instance (list :note note)))"
+  (when-let* ((buf (get-buffer (or buffer (current-buffer)))))
+    (when (buffer-live-p buf)
+      (buffer-local-value 'vui--root-instance buf))))
+
 (provide 'vui)
 ;;; vui.el ends here


### PR DESCRIPTION
vui--root-instance is buffer-local and private, so applications using
vui-rerender/vui-update had to maintain their own buffer-to-instance
storage. vui-get-instance returns the root instance mounted in a
buffer (defaulting to the current buffer), accepting either a buffer
object or a buffer name, and returns nil when the buffer does not
exist or has nothing mounted.

Closes #36

