### PR TITLE
feat: add vui-unmount with full lifecycle teardown

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,8 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-unmount= - Explicitly unmount the instance mounted in a buffer. Runs the full teardown lifecycle for the whole tree (=:on-unmount= hooks, effect cleanups, =:on-mount= cleanup functions, async process and render timer cancellation) and erases the buffer. Previously there was no way to tear a mounted UI down, so timers and processes held by components leaked.
+- Async callbacks created via =vui-with-async-context= and =vui-async-callback= now also become no-ops when their component tree has been unmounted. Previously they only checked that the buffer was still alive, so a stale timer could re-render an unmounted tree into the buffer.
 - =vui-get-instance= - Return the root instance mounted in a buffer (defaults to the current buffer). Lets applications drive a mounted UI via =vui-rerender= / =vui-update= / =vui-update-props= without maintaining their own buffer-to-instance storage (#36).
 - *Instance update API*: New public functions for re-rendering mounted instances:
   - =vui-rerender= - Re-render an instance preserving component state and memos. Useful for forcing a redraw.

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -91,6 +91,30 @@ Mount a component as root and render to a buffer.
 (vui-mount (vui-component 'my-app :title "Hello") "*my-app*")
 #+end_src
 
+** vui-unmount
+
+#+begin_src elisp
+(vui-unmount &optional BUFFER) -> instance or nil
+#+end_src
+
+Unmount the VUI instance mounted in BUFFER (default: current buffer).
+
+Runs the full teardown lifecycle for every component in the tree:
+=:on-unmount= hooks, effect cleanup functions, cleanup functions returned
+from =:on-mount=, and cancellation of pending async processes and deferred
+renders. The buffer's content is erased, but the buffer itself is not
+killed.
+
+After unmounting, async callbacks created via =vui-with-async-context= or
+=vui-async-callback= that captured this tree become no-ops.
+
+- BUFFER :: Buffer object or buffer name (default: current buffer)
+- Returns :: The unmounted instance, or nil if nothing was mounted
+
+#+begin_src elisp
+(vui-unmount "*my-app*")
+#+end_src
+
 ** vui-get-instance
 
 #+begin_src elisp

--- a/test/vui-lifecycle-test.el
+++ b/test/vui-lifecycle-test.el
@@ -1,0 +1,153 @@
+;;; vui-lifecycle-test.el --- Mount/unmount lifecycle tests for vui.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Tests for the mount/unmount lifecycle: vui-unmount, teardown on
+;; remount, teardown on buffer kill, and staleness of async callbacks
+;; created via vui-with-async-context / vui-async-callback.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+(describe "vui-unmount"
+  (it "runs on-unmount hooks for the whole tree, children first"
+    (let ((unmount-log nil))
+      (vui-defcomponent unmount-child ()
+        :on-unmount (push 'child unmount-log)
+        :render (vui-text "child"))
+      (vui-defcomponent unmount-parent ()
+        :on-unmount (push 'parent unmount-log)
+        :render (vui-component 'unmount-child))
+      (vui-mount (vui-component 'unmount-parent) "*test-unmount-tree*")
+      (unwind-protect
+          (progn
+            (expect (vui-unmount "*test-unmount-tree*") :to-be-truthy)
+            ;; Children unmount before parents (depth-first)
+            (expect (reverse unmount-log) :to-equal '(child parent)))
+        (kill-buffer "*test-unmount-tree*"))))
+
+  (it "runs effect cleanups and on-mount cleanup functions"
+    (let ((cleanups nil))
+      (vui-defcomponent unmount-cleanups ()
+        :on-mount (lambda () (push 'mount-cleanup cleanups))
+        :render (progn
+                  (vui-use-effect ()
+                    (lambda () (push 'effect-cleanup cleanups)))
+                  (vui-text "x")))
+      (vui-mount (vui-component 'unmount-cleanups) "*test-unmount-cleanups*")
+      (unwind-protect
+          (progn
+            (expect cleanups :to-equal nil)
+            (vui-unmount "*test-unmount-cleanups*")
+            (expect cleanups :to-have-same-items-as
+                    '(mount-cleanup effect-cleanup)))
+        (kill-buffer "*test-unmount-cleanups*"))))
+
+  (it "cancels a pending deferred re-render"
+    (let ((vui-render-delay 0.01)
+          (render-count 0))
+      (vui-defcomponent unmount-pending ()
+        :state ((n 0))
+        :render (progn
+                  (setq render-count (1+ render-count))
+                  (vui-text (number-to-string n))))
+      (let ((instance (vui-mount (vui-component 'unmount-pending)
+                                 "*test-unmount-pending*")))
+        (unwind-protect
+            (progn
+              (expect render-count :to-equal 1)
+              ;; Schedule a deferred render, then unmount before it fires
+              (with-current-buffer "*test-unmount-pending*"
+                (let ((vui--current-instance instance))
+                  (vui-set-state :n 1)))
+              (vui-unmount "*test-unmount-pending*")
+              (sleep-for 0.05)
+              (expect render-count :to-equal 1))
+          (kill-buffer "*test-unmount-pending*")))))
+
+  (it "erases buffer content and clears vui-get-instance"
+    (vui-defcomponent unmount-clears ()
+      :render (vui-text "content"))
+    (vui-mount (vui-component 'unmount-clears) "*test-unmount-clears*")
+    (unwind-protect
+        (progn
+          (expect (with-current-buffer "*test-unmount-clears*" (buffer-string))
+                  :to-equal "content")
+          (vui-unmount "*test-unmount-clears*")
+          (expect (vui-get-instance "*test-unmount-clears*") :to-be nil)
+          (expect (with-current-buffer "*test-unmount-clears*" (buffer-string))
+                  :to-equal ""))
+      (kill-buffer "*test-unmount-clears*")))
+
+  (it "returns nil when nothing is mounted"
+    (let ((buf (get-buffer-create "*test-unmount-nothing*")))
+      (unwind-protect
+          (expect (vui-unmount buf) :to-be nil)
+        (kill-buffer buf))))
+
+  (it "makes stale vui-with-async-context callbacks no-ops"
+    (let ((body-ran nil))
+      (vui-defcomponent unmount-stale-async ()
+        :state ((n 0))
+        :render (vui-text (number-to-string n)))
+      (let* ((instance (vui-mount (vui-component 'unmount-stale-async)
+                                  "*test-unmount-stale*"))
+             (callback (with-current-buffer "*test-unmount-stale*"
+                         (let ((vui--current-instance instance))
+                           (vui-with-async-context
+                            (setq body-ran t)
+                            (vui-set-state :n 99))))))
+        (unwind-protect
+            (progn
+              (vui-unmount "*test-unmount-stale*")
+              ;; Simulates a timer firing after unmount
+              (funcall callback)
+              (expect body-ran :to-be nil)
+              (expect (with-current-buffer "*test-unmount-stale*"
+                        (buffer-string))
+                      :to-equal ""))
+          (kill-buffer "*test-unmount-stale*")))))
+
+  (it "makes stale vui-async-callback callbacks no-ops"
+    (let ((received nil))
+      (vui-defcomponent unmount-stale-cb ()
+        :state ((data nil))
+        :render (vui-text (format "%s" data)))
+      (let* ((instance (vui-mount (vui-component 'unmount-stale-cb)
+                                  "*test-unmount-stale-cb*"))
+             (callback (with-current-buffer "*test-unmount-stale-cb*"
+                         (let ((vui--current-instance instance))
+                           (vui-async-callback (result)
+                             (setq received result)
+                             (vui-set-state :data result))))))
+        (unwind-protect
+            (progn
+              (vui-unmount "*test-unmount-stale-cb*")
+              (funcall callback 'late-data)
+              (expect received :to-be nil))
+          (kill-buffer "*test-unmount-stale-cb*")))))
+
+  (it "still runs async callbacks while mounted"
+    ;; Guard against over-eager staleness checks
+    (let ((body-ran nil))
+      (vui-defcomponent live-async ()
+        :state ((n 0))
+        :render (vui-text (number-to-string n)))
+      (let* ((instance (vui-mount (vui-component 'live-async)
+                                  "*test-live-async*"))
+             (callback (with-current-buffer "*test-live-async*"
+                         (let ((vui--current-instance instance))
+                           (vui-with-async-context
+                            (setq body-ran t))))))
+        (unwind-protect
+            (progn
+              (funcall callback)
+              (expect body-ran :to-be t))
+          (kill-buffer "*test-live-async*"))))))
+
+(provide 'vui-lifecycle-test)
+;;; vui-lifecycle-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -1227,9 +1227,11 @@ The macro captures:
 - The current component instance
 - The root instance
 
-When the returned function is called, it checks if the buffer is still
-alive, switches to it, and restores the component context before
-executing BODY."
+When the returned function is called, it checks that the buffer is
+still alive and that the captured component tree has not been
+unmounted (see `vui-unmount'); if either check fails, BODY is
+skipped.  Otherwise it switches to the buffer and restores the
+component context before executing BODY."
   (let ((buf (make-symbol "buf"))
         (instance (make-symbol "instance"))
         (root (make-symbol "root")))
@@ -1237,7 +1239,8 @@ executing BODY."
            (,instance vui--current-instance)
            (,root vui--root-instance))
       (lambda ()
-        (when (buffer-live-p ,buf)
+        (when (and (buffer-live-p ,buf)
+                   (or (null ,root) (vui-instance-buffer ,root)))
          (with-current-buffer ,buf
           (let ((vui--current-instance ,instance)
                 (vui--root-instance ,root))
@@ -1263,7 +1266,10 @@ Example:
 
 Compare with `vui-with-async-context':
 - `vui-with-async-context' - for fire-and-forget callbacks (timers)
-- `vui-async-callback' - when callback receives data from async operation"
+- `vui-async-callback' - when callback receives data from async operation
+
+Like `vui-with-async-context', the callback does nothing when its
+buffer has been killed or its component tree has been unmounted."
   (declare (indent defun))
   (let ((buf (make-symbol "buf"))
         (instance (make-symbol "instance"))
@@ -1272,7 +1278,8 @@ Compare with `vui-with-async-context':
            (,instance vui--current-instance)
            (,root vui--root-instance))
       (lambda ,args
-        (when (buffer-live-p ,buf)
+        (when (and (buffer-live-p ,buf)
+                   (or (null ,root) (vui-instance-buffer ,root)))
          (with-current-buffer ,buf
           (let ((vui--current-instance ,instance)
                 (vui--root-instance ,root))
@@ -2235,6 +2242,27 @@ INSTANCE is the component instance."
      (vui-instance-state instance))
     (vui--timing-record 'unmount component-name)))
 
+(defun vui--detach-instance (instance)
+  "Clear buffer references for INSTANCE and all its children, recursively.
+A detached instance can no longer be re-rendered: `vui--rerender-instance'
+becomes a no-op for it, and async callbacks created via
+`vui-with-async-context' that captured it do nothing."
+  (setf (vui-instance-buffer instance) nil)
+  (dolist (child (vui-instance-children instance))
+    (vui--detach-instance child)))
+
+(defun vui--unmount-root (instance)
+  "Run full lifecycle teardown for root INSTANCE and detach it.
+Calls on-unmount hooks, effect cleanups, on-mount cleanup functions,
+and async process cleanup for the whole tree, cancels any pending
+deferred render, and clears buffer references so stale re-render
+requests for this tree become no-ops."
+  (vui--call-unmount-recursive instance)
+  ;; Cancel after cleanups: an on-unmount hook calling `vui-set-state'
+  ;; would otherwise leave a fresh timer behind.
+  (vui--cancel-render-timer instance)
+  (vui--detach-instance instance))
+
 (defun vui--find-matching-child (parent type key index)
   "Find a child of PARENT matching TYPE and KEY or INDEX."
   (when parent
@@ -3081,6 +3109,33 @@ Use this together with `vui-rerender', `vui-update', and
   (when-let* ((buf (get-buffer (or buffer (current-buffer)))))
     (when (buffer-live-p buf)
       (buffer-local-value 'vui--root-instance buf))))
+
+(defun vui-unmount (&optional buffer)
+  "Unmount the VUI instance mounted in BUFFER (default: current buffer).
+BUFFER may be a buffer object or a buffer name.
+
+Runs the full teardown lifecycle for every component in the tree:
+on-unmount hooks, effect cleanup functions, cleanup functions
+returned from on-mount, and cancellation of pending async processes
+and deferred renders.  The buffer's content is erased, but the
+buffer itself is not killed.
+
+After unmounting, async callbacks created via
+`vui-with-async-context' or `vui-async-callback' that captured this
+tree become no-ops.
+
+Returns the unmounted instance, or nil if BUFFER does not exist or
+has no mounted instance."
+  (when-let* ((instance (vui-get-instance buffer)))
+    (let ((buf (vui-instance-buffer instance)))
+      (vui--unmount-root instance)
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (kill-local-variable 'vui--root-instance)
+          (let ((inhibit-read-only t))
+            (remove-overlays)
+            (erase-buffer)))))
+    instance))
 
 (provide 'vui)
 ;;; vui.el ends here


### PR DESCRIPTION
There was no way to tear down a mounted UI: on-unmount hooks, effect
cleanups, and on-mount cleanup functions only ran for components
removed during a re-render, never for the whole tree. Timers and
processes held by components leaked, and async callbacks created via
vui-with-async-context stayed live as long as the buffer existed,
able to re-render a dead tree into the buffer.

vui-unmount runs the complete teardown lifecycle for every component
in the tree (on-unmount hooks, effect cleanups, on-mount cleanup
functions, async process and render timer cancellation), erases the
buffer, and detaches the tree by clearing its buffer references.
Detached trees can no longer be re-rendered, and vui-with-async-context
/ vui-async-callback callbacks that captured them become no-ops.

