### PR TITLE
fix: unmount existing tree when remounting into the same buffer

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-mount= now unmounts a previously mounted tree before mounting into the same buffer. Previously the old tree stayed live without any teardown: its cleanups never ran and a timer created by it could re-render the old UI over the new mount.
 - Deferred re-renders now use a per-instance timer instead of a single global one. Previously, state updates in two VUI buffers within the same =vui-render-delay= window cancelled each other's pending render, silently leaving the first buffer stale. =vui-flush-sync= likewise no longer cancels pending renders that belong to other buffers.
 - Disabled buttons now use =widget-inactive= face instead of the regular button face.
 - Button =:tab-order= and =:keymap= properties are now preserved when buttons are truncated in table cells.

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -83,6 +83,10 @@ In =:on-update= and =:should-update= additionally:
 
 Mount a component as root and render to a buffer.
 
+If the buffer already has a mounted instance, it is unmounted first
+(see =vui-unmount=), so the old tree's lifecycle cleanups run before the
+new tree renders.
+
 - COMPONENT-VNODE :: Created with =vui-component=
 - BUFFER-NAME :: String (default ="*vui*"=)
 - Returns :: The root instance

--- a/test/vui-lifecycle-test.el
+++ b/test/vui-lifecycle-test.el
@@ -149,5 +149,48 @@
               (expect body-ran :to-be t))
           (kill-buffer "*test-live-async*"))))))
 
+(describe "remounting into the same buffer"
+  (it "unmounts the previous tree first"
+    (let ((unmounted nil))
+      (vui-defcomponent remount-old ()
+        :on-unmount (setq unmounted t)
+        :render (vui-text "OLD"))
+      (vui-defcomponent remount-new ()
+        :render (vui-text "NEW"))
+      (vui-mount (vui-component 'remount-old) "*test-remount*")
+      (unwind-protect
+          (progn
+            (expect unmounted :to-be nil)
+            (vui-mount (vui-component 'remount-new) "*test-remount*")
+            (expect unmounted :to-be t)
+            (expect (with-current-buffer "*test-remount*" (buffer-string))
+                    :to-equal "NEW"))
+        (kill-buffer "*test-remount*"))))
+
+  (it "prevents stale async callbacks from clobbering the new mount"
+    (vui-defcomponent remount-stale-old ()
+      :state ((x 0))
+      :render (vui-text (format "OLD %d" x)))
+    (vui-defcomponent remount-stale-new ()
+      :render (vui-text "NEW"))
+    (let* ((old (vui-mount (vui-component 'remount-stale-old)
+                           "*test-remount-stale*"))
+           ;; Simulates a timer callback created by the old tree
+           (callback (with-current-buffer "*test-remount-stale*"
+                       (let ((vui--current-instance old))
+                         (vui-with-async-context
+                          (vui-set-state :x 99))))))
+      (unwind-protect
+          (progn
+            (vui-mount (vui-component 'remount-stale-new)
+                       "*test-remount-stale*")
+            ;; Old tree's timer fires after the new mount
+            (funcall callback)
+            (sleep-for 0.05)
+            (expect (with-current-buffer "*test-remount-stale*"
+                      (buffer-string))
+                    :to-equal "NEW"))
+        (kill-buffer "*test-remount-stale*")))))
+
 (provide 'vui-lifecycle-test)
 ;;; vui-lifecycle-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -3073,6 +3073,12 @@ Returns the root instance."
     (setf (vui-instance-buffer instance) buf)
     (with-current-buffer buf
       (let ((inhibit-read-only t))
+        ;; Tear down any previously mounted tree first so its lifecycle
+        ;; cleanups run and its stale async callbacks detach.  Without
+        ;; this, the old tree stays live and a timer created by it can
+        ;; re-render the old UI over the new mount.
+        (when vui--root-instance
+          (vui--unmount-root vui--root-instance))
         ;; Enable vui-mode (this also sets up the keymap hierarchy)
         (unless (derived-mode-p 'vui-mode)
           (vui-mode))


### PR DESCRIPTION
vui-mount over a live root left the old tree fully alive: none of its
lifecycle cleanups ran, and async callbacks created by it (timers,
process sentinels) still passed their buffer-liveness check, so a
stale callback could re-render the OLD tree over the NEW mount,
corrupting the buffer.

Tear down the existing root before mounting, reusing the vui-unmount
lifecycle so cleanups run and the old tree detaches.

