### PR TITLE
fix: run unmount lifecycle when a vui buffer is killed

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- Killing a VUI buffer now runs the full unmount lifecycle for the mounted tree. Previously =:on-unmount= hooks, effect cleanups, and =:on-mount= cleanup functions never ran on buffer kill, so timers and processes held by components leaked.
 - =vui-mount= now unmounts a previously mounted tree before mounting into the same buffer. Previously the old tree stayed live without any teardown: its cleanups never ran and a timer created by it could re-render the old UI over the new mount.
 - Deferred re-renders now use a per-instance timer instead of a single global one. Previously, state updates in two VUI buffers within the same =vui-render-delay= window cancelled each other's pending render, silently leaving the first buffer stale. =vui-flush-sync= likewise no longer cancels pending renders that belong to other buffers.
 - Disabled buttons now use =widget-inactive= face instead of the regular button face.

--- a/docs/guide/07-lifecycle.org
+++ b/docs/guide/07-lifecycle.org
@@ -115,6 +115,19 @@ Runs before the component is removed from the tree:
   (vui-text "I'm here for now"))
 #+end_src
 
+Unmount happens when:
+
+- a re-render no longer includes the component in the tree,
+- =vui-unmount= is called on the buffer,
+- =vui-mount= mounts a new tree into the same buffer (the old tree is
+  unmounted first), or
+- the buffer is killed.
+
+In all cases the same teardown runs for every component in the affected
+subtree: effect cleanups, cleanup functions returned from =:on-mount=,
+pending async processes are cancelled, and =:on-unmount= hooks fire
+(children before parents).
+
 ** Use Cases
 
 - Canceling timers

--- a/test/vui-lifecycle-test.el
+++ b/test/vui-lifecycle-test.el
@@ -192,5 +192,48 @@
                     :to-equal "NEW"))
         (kill-buffer "*test-remount-stale*")))))
 
+(describe "buffer kill teardown"
+  (it "runs lifecycle cleanups when the buffer is killed"
+    (let ((cleanups nil))
+      (vui-defcomponent kill-cleanup-test ()
+        :on-mount (lambda () (push 'mount-cleanup cleanups))
+        :on-unmount (push 'unmounted cleanups)
+        :render (progn
+                  (vui-use-effect ()
+                    (lambda () (push 'effect-cleanup cleanups)))
+                  (vui-text "x")))
+      (vui-mount (vui-component 'kill-cleanup-test) "*test-kill-cleanup*")
+      (expect cleanups :to-equal nil)
+      (kill-buffer "*test-kill-cleanup*")
+      (expect cleanups :to-have-same-items-as
+              '(mount-cleanup effect-cleanup unmounted))))
+
+  (it "cancels timers held by components when the buffer is killed"
+    ;; The README's timer pattern: on-mount starts a timer, returns a
+    ;; cleanup that cancels it. Killing the buffer must cancel the timer.
+    (let ((timer-cancelled nil))
+      (vui-defcomponent kill-timer-test ()
+        :on-mount
+        (let ((timer (run-with-timer 100 nil #'ignore)))
+          (lambda ()
+            (cancel-timer timer)
+            (setq timer-cancelled t)))
+        :render (vui-text "x"))
+      (vui-mount (vui-component 'kill-timer-test) "*test-kill-timer*")
+      (expect timer-cancelled :to-be nil)
+      (kill-buffer "*test-kill-timer*")
+      (expect timer-cancelled :to-be t)))
+
+  (it "does not run cleanups twice when unmounted before kill"
+    (let ((unmount-count 0))
+      (vui-defcomponent kill-once-test ()
+        :on-unmount (cl-incf unmount-count)
+        :render (vui-text "x"))
+      (vui-mount (vui-component 'kill-once-test) "*test-kill-once*")
+      (vui-unmount "*test-kill-once*")
+      (expect unmount-count :to-equal 1)
+      (kill-buffer "*test-kill-once*")
+      (expect unmount-count :to-equal 1))))
+
 (provide 'vui-lifecycle-test)
 ;;; vui-lifecycle-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -3086,6 +3086,8 @@ Returns the root instance."
         (erase-buffer)
         ;; Store root instance for state updates
         (setq-local vui--root-instance instance)
+        ;; Release component resources when the buffer is killed
+        (add-hook 'kill-buffer-hook #'vui--teardown-on-kill nil t)
         (let ((vui--root-instance instance))
           ;; Set rendering flag to prevent nested re-renders from sync resolve
           (setq vui--rendering-p t)
@@ -3115,6 +3117,15 @@ Use this together with `vui-rerender', `vui-update', and
   (when-let* ((buf (get-buffer (or buffer (current-buffer)))))
     (when (buffer-live-p buf)
       (buffer-local-value 'vui--root-instance buf))))
+
+(defun vui--teardown-on-kill ()
+  "Run the unmount lifecycle for the current buffer's root instance.
+Installed buffer-locally on `kill-buffer-hook' by `vui-mount' so
+components release their resources (timers, processes, subscriptions)
+when the buffer is killed."
+  (when vui--root-instance
+    (vui--unmount-root vui--root-instance)
+    (kill-local-variable 'vui--root-instance)))
 
 (defun vui-unmount (&optional buffer)
   "Unmount the VUI instance mounted in BUFFER (default: current buffer).


### PR DESCRIPTION
Killing a VUI buffer never ran any teardown: on-unmount hooks, effect
cleanups, and on-mount cleanup functions only fired for components
removed during a re-render. Timers and processes held by components
leaked - including the timer pattern shown in the README and the
lifecycle guide.

Install a buffer-local kill-buffer-hook at mount that runs the same
teardown as vui-unmount. Explicitly unmounted buffers are not torn
down twice.

