### PR TITLE
fix: make vui-use-callback* and vui-use-memo* work as documented

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-use-callback*= and =vui-use-memo*= were unusable as documented: plain =defmacro= does not support =&key=, so the documented =:compare eq= syntax signalled =void-variable=, and omitting =:compare= failed to macro-expand with wrong-number-of-arguments. Only the accidental =:compare 'eq= form worked. Both macros now parse =:compare= from the body; bare =eq= / =equal=, quoted symbols, and comparison functions all work, and =:compare= may be omitted.
 - Killing a VUI buffer now runs the full unmount lifecycle for the mounted tree. Previously =:on-unmount= hooks, effect cleanups, and =:on-mount= cleanup functions never ran on buffer kill, so timers and processes held by components leaked.
 - =vui-mount= now unmounts a previously mounted tree before mounting into the same buffer. Previously the old tree stayed live without any teardown: its cleanups never ran and a timer created by it could re-render the old UI over the new mount.
 - Deferred re-renders now use a per-instance timer instead of a single global one. Previously, state updates in two VUI buffers within the same =vui-render-delay= window cancelled each other's pending render, silently leaving the first buffer stale. =vui-flush-sync= likewise no longer cancels pending renders that belong to other buffers.

--- a/test/vui-hooks-test.el
+++ b/test/vui-hooks-test.el
@@ -376,6 +376,107 @@
             (expect result :to-equal 42)
           (kill-buffer "*test-cb3*"))))))
 
+(describe "use-callback* and use-memo* comparison modes"
+  (it "vui-use-callback* accepts bare eq as documented"
+    ;; The documented syntax: :compare eq (unquoted)
+    (let ((captured-fns nil))
+      (vui-defcomponent callback-star-bare ()
+        :state ((mode 'view))
+        :render (let ((cb (vui-use-callback* (mode)
+                            :compare eq
+                            (ignore mode))))
+                  (push cb captured-fns)
+                  (vui-text "x")))
+      (let ((instance (vui-mount (vui-component 'callback-star-bare)
+                                 "*test-cbs1*")))
+        (unwind-protect
+            (progn
+              (vui--rerender-instance instance)
+              (expect (length captured-fns) :to-equal 2)
+              (expect (nth 0 captured-fns) :to-be (nth 1 captured-fns)))
+          (kill-buffer "*test-cbs1*")))))
+
+  (it "vui-use-callback* works without :compare"
+    (let ((captured-fns nil))
+      (vui-defcomponent callback-star-default ()
+        :state ((n 0))
+        :render (let ((cb (vui-use-callback* (n)
+                            (ignore n))))
+                  (push cb captured-fns)
+                  (vui-text "x")))
+      (let ((instance (vui-mount (vui-component 'callback-star-default)
+                                 "*test-cbs2*")))
+        (unwind-protect
+            (progn
+              (vui--rerender-instance instance)
+              (expect (length captured-fns) :to-equal 2)
+              (expect (nth 0 captured-fns) :to-be (nth 1 captured-fns)))
+          (kill-buffer "*test-cbs2*")))))
+
+  (it "vui-use-memo* accepts bare eq as documented"
+    (let ((compute-count 0))
+      (vui-defcomponent memo-star-bare ()
+        :state ((mode 'view))
+        :render (let ((result (vui-use-memo* (mode)
+                                :compare eq
+                                (cl-incf compute-count)
+                                (symbol-name mode))))
+                  (vui-text result)))
+      (let ((instance (vui-mount (vui-component 'memo-star-bare)
+                                 "*test-memo-bare*")))
+        (unwind-protect
+            (progn
+              (expect compute-count :to-equal 1)
+              ;; Same symbol - cached
+              (vui--rerender-instance instance)
+              (expect compute-count :to-equal 1)
+              ;; Different symbol - recompute
+              (setf (vui-instance-state instance)
+                    (plist-put (vui-instance-state instance) :mode 'edit))
+              (vui--rerender-instance instance)
+              (expect compute-count :to-equal 2))
+          (kill-buffer "*test-memo-bare*")))))
+
+  (it "vui-use-memo* works without :compare"
+    (let ((compute-count 0))
+      (vui-defcomponent memo-star-default ()
+        :state ((n 0))
+        :render (let ((result (vui-use-memo* (n)
+                                (cl-incf compute-count)
+                                (number-to-string n))))
+                  (vui-text result)))
+      (let ((instance (vui-mount (vui-component 'memo-star-default)
+                                 "*test-memo-default*")))
+        (unwind-protect
+            (progn
+              (expect compute-count :to-equal 1)
+              (vui--rerender-instance instance)
+              (expect compute-count :to-equal 1))
+          (kill-buffer "*test-memo-default*")))))
+
+  (it "vui-use-memo* accepts a custom comparison function"
+    (let ((compute-count 0))
+      (vui-defcomponent memo-star-custom ()
+        :state ((n 0))
+        :render (let ((result (vui-use-memo* (n)
+                                ;; Treat all deps as equal: never recompute
+                                :compare (lambda (_old _new) t)
+                                (cl-incf compute-count)
+                                (number-to-string n))))
+                  (ignore result)
+                  (vui-text (number-to-string n))))
+      (let ((instance (vui-mount (vui-component 'memo-star-custom)
+                                 "*test-memo-custom*")))
+        (unwind-protect
+            (progn
+              (expect compute-count :to-equal 1)
+              ;; Change deps; custom comparator says equal, so cached
+              (setf (vui-instance-state instance)
+                    (plist-put (vui-instance-state instance) :n 1))
+              (vui--rerender-instance instance)
+              (expect compute-count :to-equal 1))
+          (kill-buffer "*test-memo-custom*"))))))
+
 (describe "use-memo"
   (it "caches computed value across re-renders"
     (let ((compute-count 0))

--- a/vui.el
+++ b/vui.el
@@ -1593,27 +1593,45 @@ not a function returning a callback."
     (list ,@deps)
     (lambda () ,@body)))
 
-(defmacro vui-use-callback* (deps &key compare &rest body)
+(defmacro vui-use-callback* (deps &rest body)
   "Like `vui-use-callback' but with configurable comparison mode.
 
 DEPS is a list of variables to watch.
-COMPARE specifies comparison mode:
+BODY may start with `:compare MODE' to select how deps are compared:
   `eq'     - identity comparison (fastest, for symbols/numbers)
   `equal'  - structural comparison (default)
-  function - custom (lambda (old-deps new-deps) bool)
+  form     - any other form is evaluated and must yield a function
+             (lambda (old-deps new-deps) bool)
 
-Example:
+The bare symbols `eq' and `equal' and the quoted forms \\='eq and
+\\='equal are interchangeable.
+
+Examples:
   ;; Use eq for fast symbol comparison
   (vui-use-callback* (action-type)
     :compare eq
     (dispatch action-type))
 
-BODY is the callback expression itself, not a function returning a callback."
+  ;; Custom comparison function
+  (vui-use-callback* (items)
+    :compare (lambda (old new) (equal (car old) (car new)))
+    (process items))
+
+The rest of BODY is the callback expression itself, not a function
+returning a callback."
   (declare (indent 1))
-  `(vui--get-or-update-callback
-    (list ,@deps)
-    (lambda () ,@body)
-    ,compare))
+  (let ((compare nil))
+    (when (eq (car body) :compare)
+      (setq compare (cadr body)
+            body (cddr body)))
+    ;; Bare `eq' / `equal' name the built-in comparison modes; any
+    ;; other form is evaluated (a quoted symbol, lambda, #'fn, ...).
+    (when (memq compare '(eq equal))
+      (setq compare (list 'quote compare)))
+    `(vui--get-or-update-callback
+      (list ,@deps)
+      (lambda () ,@body)
+      ,compare)))
 
 (defun vui--deps-equal-p (old-deps new-deps compare)
   "Compare OLD-DEPS and NEW-DEPS using COMPARE mode.
@@ -1679,27 +1697,44 @@ Example:
     (list ,@deps)
     (lambda () ,@body)))
 
-(defmacro vui-use-memo* (deps &key compare &rest body)
+(defmacro vui-use-memo* (deps &rest body)
   "Like `vui-use-memo' but with configurable comparison mode.
 
 DEPS is a list of variables to watch.
-COMPARE specifies comparison mode:
+BODY may start with `:compare MODE' to select how deps are compared:
   `eq'     - identity comparison (fastest, for symbols/numbers)
   `equal'  - structural comparison (default)
-  function - custom (lambda (old-deps new-deps) bool)
+  form     - any other form is evaluated and must yield a function
+             (lambda (old-deps new-deps) bool)
 
-Example:
+The bare symbols `eq' and `equal' and the quoted forms \\='eq and
+\\='equal are interchangeable.
+
+Examples:
   ;; Use eq for fast symbol comparison
   (vui-use-memo* (mode)
     :compare eq
     (expensive-lookup mode))
 
-BODY is the expression to compute and cache."
+  ;; Custom comparison function
+  (vui-use-memo* (items)
+    :compare (lambda (old new) (equal (car old) (car new)))
+    (process-items items))
+
+The rest of BODY is the expression to compute and cache."
   (declare (indent 1))
-  `(vui--get-or-update-memo
-    (list ,@deps)
-    (lambda () ,@body)
-    ,compare))
+  (let ((compare nil))
+    (when (eq (car body) :compare)
+      (setq compare (cadr body)
+            body (cddr body)))
+    ;; Bare `eq' / `equal' name the built-in comparison modes; any
+    ;; other form is evaluated (a quoted symbol, lambda, #'fn, ...).
+    (when (memq compare '(eq equal))
+      (setq compare (list 'quote compare)))
+    `(vui--get-or-update-memo
+      (list ,@deps)
+      (lambda () ,@body)
+      ,compare)))
 
 (defun vui--get-or-update-memo (deps compute-fn &optional compare)
   "Return cached value or recompute if DEPS changed.


### PR DESCRIPTION
Plain defmacro does not support &key, so in (deps &key compare &rest
body) the &key symbol was treated as a positional parameter. The
documented syntax (:compare eq) expanded the bare symbol into an
evaluated position and signalled void-variable at runtime; omitting
:compare entirely failed to macro-expand with
wrong-number-of-arguments. Only the accidental form :compare 'eq
worked, which is what the single existing test used, so CI never
caught it.

Parse :compare from the head of the body instead. Bare eq/equal are
treated as literal mode names; any other form (quoted symbol, lambda,
function reference) is evaluated, keeping all previously-working call
shapes compatible.

