### PR TITLE
feat: render vui-field placeholder while the field is empty

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-field= =:placeholder= is now actually rendered: while the field is empty, the placeholder is shown in the new =vui-field-placeholder= face (inherits =shadow=), padded or truncated to the field's =:size=, and disappears the moment the field is modified. The prop was previously accepted and documented but never displayed.
 - =vui-list= no longer requires an explicit nil key-fn before keyword options: =(vui-list items render-fn :indent 2)= now works. Previously the keyword was consumed as the key function and the call failed with a confusing "Keyword argument 2 not one of ..." error. Positional key-fn calls are unchanged, and unknown options still signal an error.
 - =vui-component= no longer drops props that appear after =:children= in the argument plist. Previously parsing stopped at =:children=, silently discarding everything after it.
 - Layout measurement no longer has side effects. Tables and =vui-box= render their content twice (a measure pass, then the real pass); the measure pass used to instantiate real component instances, so =:on-mount= fired up to three times per table cell per render, effects registered by cell components re-ran on every render, =vui-use-async= loaders started once per measure pass, and a component inside =vui-box= was reconciled twice per render (duplicating child entries and shifting indexes for keyless siblings). Measure passes now skip lifecycle hooks, discard effect registrations, and do not start async loaders.

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -321,7 +321,7 @@ fields with parsing and validation, use =vui-typed-field= from =vui-components.e
 |----------------+----------+---------------------------------|
 | =:value=       | string   | Initial content (default "")    |
 | =:size=        | integer  | Width in characters             |
-| =:placeholder= | string   | Hint text (not yet rendered)    |
+| =:placeholder= | string   | Hint text shown while empty     |
 | =:on-change=   | function | Called with value on change     |
 | =:on-submit=   | function | Called with value on RET        |
 | =:key=         | any      | Reconciliation key / lookup key |

--- a/test/vui-test.el
+++ b/test/vui-test.el
@@ -210,6 +210,60 @@ Buttons are widget.el push-buttons, so we use widget-apply."
               (expect submitted-value :to-equal "initial"))
           (kill-buffer "*test-submit*"))))))
 
+(defun vui-test--placeholder-overlays ()
+  "Return all placeholder overlays in the current buffer."
+  (seq-filter (lambda (ov) (overlay-get ov 'vui-placeholder))
+              (overlays-in (point-min) (point-max))))
+
+(describe "vui-field placeholder"
+  (it "shows placeholder while the field is empty"
+    (with-temp-buffer
+      (vui-render (vui-field :size 10 :placeholder "Name..."))
+      (let ((overlays (vui-test--placeholder-overlays)))
+        (expect (length overlays) :to-equal 1)
+        (let ((display (overlay-get (car overlays) 'display)))
+          (expect display :to-match "Name\\.\\.\\.")
+          (expect (get-text-property 0 'face display)
+                  :to-equal 'vui-field-placeholder)))))
+
+  (it "does not show placeholder when the field has a value"
+    (with-temp-buffer
+      (vui-render (vui-field :value "Boris" :size 10 :placeholder "Name..."))
+      (expect (vui-test--placeholder-overlays) :to-equal nil)))
+
+  (it "hides placeholder as soon as the user types"
+    (with-temp-buffer
+      (vui-render (vui-field :size 10 :placeholder "Name..."))
+      (expect (length (vui-test--placeholder-overlays)) :to-equal 1)
+      (let ((widget (car widget-field-list)))
+        (widget-value-set widget "B"))
+      (expect (vui-test--placeholder-overlays) :to-equal nil)))
+
+  (it "pads and truncates the placeholder to the field size"
+    (with-temp-buffer
+      (vui-render (vui-field :size 4 :placeholder "Very long placeholder"))
+      (let ((display (overlay-get (car (vui-test--placeholder-overlays))
+                                  'display)))
+        (expect (length display) :to-equal 4)))
+    (with-temp-buffer
+      (vui-render (vui-field :size 10 :placeholder "ab"))
+      (let ((display (overlay-get (car (vui-test--placeholder-overlays))
+                                  'display)))
+        (expect (length display) :to-equal 10))))
+
+  (it "does not accumulate overlays across re-renders"
+    (vui-defcomponent placeholder-rerender-test ()
+      :render (vui-field :size 10 :placeholder "Type here"))
+    (let ((instance (vui-mount (vui-component 'placeholder-rerender-test)
+                               "*test-placeholder-rerender*")))
+      (unwind-protect
+          (progn
+            (vui--rerender-instance instance)
+            (vui--rerender-instance instance)
+            (with-current-buffer "*test-placeholder-rerender*"
+              (expect (length (vui-test--placeholder-overlays)) :to-equal 1)))
+        (kill-buffer "*test-placeholder-rerender*")))))
+
 (describe "vui-field-value"
   (it "retrieves field value by key"
     (vui-defcomponent field-value-test ()

--- a/vui.el
+++ b/vui.el
@@ -77,6 +77,12 @@ Same options as `vui-lifecycle-error-handler'."
 Stored as (TYPE ERROR CONTEXT) where TYPE is `lifecycle' or `event',
 ERROR is the error object, and CONTEXT is additional information.")
 
+;;; Faces
+
+(defface vui-field-placeholder '((t :inherit shadow))
+  "Face for placeholder text shown in empty fields."
+  :group 'vui)
+
 ;;; Timing Instrumentation
 
 (defcustom vui-timing-enabled nil
@@ -880,7 +886,8 @@ When :keymap is set, this keymap is active when point is on the button."
 All arguments are keyword-based:
   :VALUE       - initial field content (defaults to empty string)
   :SIZE        - field width in characters
-  :PLACEHOLDER - hint text shown when field is empty (not yet rendered)
+  :PLACEHOLDER - hint text shown in `vui-field-placeholder' face
+                 while the field is empty
   :ON-CHANGE   - called with value on each change (triggers re-render)
   :ON-SUBMIT   - called with value when user presses RET (no re-render)
   :KEY         - identifier for `vui-field-value' lookup
@@ -2056,6 +2063,7 @@ mid-render."
                 (progn
                   (vui--render-instance instance)
                   (widget-setup)
+                  (vui--setup-field-placeholders)
                   ;; Restore cursor position
                   (vui--restore-cursor-position cursor-info)
                   ;; Restore viewport for all windows
@@ -2225,8 +2233,42 @@ PATH is a list representing the widget's location in the component tree."
   (dolist (ov (overlays-in (point-min) (point-max)))
     (when (or (overlay-get ov 'button)
               (overlay-get ov 'widget)
-              (overlay-get ov 'field))
+              (overlay-get ov 'field)
+              (overlay-get ov 'vui-placeholder))
       (delete-overlay ov))))
+
+(defun vui--field-add-placeholder (widget)
+  "Show WIDGET's placeholder while its field is empty.
+The placeholder (stored as :vui-placeholder on WIDGET) is displayed
+over the empty field with the `vui-field-placeholder' face, padded or
+truncated to the field's :size.  It disappears as soon as the field
+is modified."
+  (when-let* ((placeholder (widget-get widget :vui-placeholder)))
+    (when (string-empty-p (widget-value widget))
+      (let ((start (widget-field-start widget))
+            (end (widget-field-end widget))
+            (size (widget-get widget :size)))
+        (when (and start end (> end start))
+          (let ((overlay (make-overlay start end))
+                (hide (lambda (ov &rest _) (delete-overlay ov))))
+            (overlay-put overlay 'vui-placeholder t)
+            (overlay-put overlay 'display
+                         (propertize
+                          (truncate-string-to-width
+                           placeholder (or size (string-width placeholder))
+                           nil ?\s)
+                          'face 'vui-field-placeholder))
+            ;; Hide the placeholder the moment the field is modified;
+            ;; the next re-render decides whether to show it again
+            (overlay-put overlay 'modification-hooks (list hide))
+            (overlay-put overlay 'insert-in-front-hooks (list hide))
+            (overlay-put overlay 'insert-behind-hooks (list hide))))))))
+
+(defun vui--setup-field-placeholders ()
+  "Add placeholder overlays to empty fields that declare one.
+Must run after `widget-setup', which finalizes field boundaries."
+  (dolist (widget widget-field-list)
+    (vui--field-add-placeholder widget)))
 
 (defun vui--handle-error (type hook-name err instance)
   "Handle an error ERR caught in HOOK-NAME.
@@ -3126,7 +3168,8 @@ Handles :truncate and overflow:
         ;; Store key on widget for vui-field-value lookup
         (when field-key
           (widget-put w :vui-key field-key))
-        ;; Store placeholder on widget for potential future use
+        ;; Store placeholder on widget; rendered after widget-setup
+        ;; by `vui--setup-field-placeholders'
         (when placeholder
           (widget-put w :vui-placeholder placeholder)))))
 
@@ -3213,6 +3256,7 @@ Clears the buffer before rendering."
       (vui--render-vnode vnode)
       ;; Setup widgets for keyboard navigation
       (widget-setup)
+      (vui--setup-field-placeholders)
       (goto-char (point-min)))))
 
 (defun vui-render-to-buffer (buffer-name vnode)
@@ -3263,6 +3307,7 @@ Returns the root instance."
                 ;; prevent editing outside of editable fields - no need
                 ;; for buffer-read-only
                 (widget-setup)
+                (vui--setup-field-placeholders)
                 ;; Run effects after initial render
                 (vui--run-pending-effects))
             (setq vui--rendering-p nil))


### PR DESCRIPTION
The :placeholder prop was accepted, stored on the widget, and
documented in the guide and API reference, but never displayed.

Show it with an overlay over the empty field area, in the new
vui-field-placeholder face (inherits shadow), padded or truncated to
the field's :size so the layout stays stable. The overlay deletes
itself on the first modification of the field, and re-render cleanup
removes it like other widget overlays, so overlays never accumulate.

