### PR TITLE
fix: show vui-select labels and pass option values to on-change

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-select= now shows option labels: for =(value . label)= options, the button text and the completion candidates display the labels, and =:on-change= receives the corresponding value (any Lisp object, e.g. a symbol or number). Previously the raw alist went to =completing-read=, so users completed on the values, labels were never shown, and =:on-change= received whatever string completion returned.
 - =vui-field= =:placeholder= is now actually rendered: while the field is empty, the placeholder is shown in the new =vui-field-placeholder= face (inherits =shadow=), padded or truncated to the field's =:size=, and disappears the moment the field is modified. The prop was previously accepted and documented but never displayed.
 - =vui-list= no longer requires an explicit nil key-fn before keyword options: =(vui-list items render-fn :indent 2)= now works. Previously the keyword was consumed as the key function and the call failed with a confusing "Keyword argument 2 not one of ..." error. Positional key-fn calls are unchanged, and unknown options still signal an error.
 - =vui-component= no longer drops props that appear after =:children= in the argument plist. Previously parsing stopped at =:children=, silently discarding everything after it.

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -384,13 +384,19 @@ Create a checkbox.
 
 Create a selection button (minibuffer-based selection).
 
-| Property     | Type      | Description                        |
-|--------------+-----------+------------------------------------|
-| =:value=     | string    | Current selection                  |
-| =:options=   | list      | List of options (strings or alist) |
-| =:on-change= | function  | Called with selected value         |
-| =:prompt=    | string    | Minibuffer prompt (default "Select: ") |
-| =:key=       | any       | Reconciliation key                 |
+| Property     | Type      | Description                              |
+|--------------+-----------+------------------------------------------|
+| =:value=     | any       | Current selection (an option's value)    |
+| =:options=   | list      | Strings, or =(value . label)= cons cells |
+| =:on-change= | function  | Called with the selected option's value  |
+| =:prompt=    | string    | Minibuffer prompt (default "Select: ")   |
+| =:key=       | any       | Reconciliation key                       |
+
+For =(value . label)= options, the button text and completion candidates
+show the labels, while =:on-change= receives the corresponding value -
+which may be any Lisp object (symbol, number, string). Labels should be
+unique; otherwise the first matching option wins. Plain string options
+are their own label.
 
 #+begin_src elisp
 ;; Simple list
@@ -398,11 +404,11 @@ Create a selection button (minibuffer-based selection).
             :options '("light" "dark" "system")
             :on-change (lambda (v) (vui-set-state :theme v)))
 
-;; Alist with display values
+;; Values with display labels - on-change receives 'active etc.
 (vui-select :value status
-            :options '(("active" . "Active")
-                       ("pending" . "Pending")
-                       ("closed" . "Closed"))
+            :options '((active . "Active")
+                       (pending . "Pending")
+                       (closed . "Closed"))
             :on-change (lambda (v) (vui-set-state :status v)))
 #+end_src
 

--- a/test/vui-test.el
+++ b/test/vui-test.el
@@ -364,7 +364,51 @@ Buttons are widget.el push-buttons, so we use widget-apply."
   (it "renders placeholder when no value"
     (with-temp-buffer
       (vui-render (vui-select :value nil :options '("a" "b")))
-      (expect (buffer-string) :to-match "Select..."))))
+      (expect (buffer-string) :to-match "Select...")))
+
+  (it "shows the label of the current value on the button"
+    (with-temp-buffer
+      (vui-render (vui-select :value "a"
+                              :options '(("a" . "Apple") ("b" . "Banana"))))
+      (expect (buffer-string) :to-match "Apple")))
+
+  (it "completes on labels and passes the value to on-change"
+    (let ((received 'unset)
+          (candidates nil))
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (_prompt collection &rest _)
+                   (setq candidates collection)
+                   "Banana")))
+        (with-temp-buffer
+          (vui-render (vui-select :value "a"
+                                  :options '(("a" . "Apple") ("b" . "Banana"))
+                                  :on-change (lambda (v) (setq received v))))
+          (widget-apply (widget-at (point-min)) :notify)))
+      (expect candidates :to-equal '("Apple" "Banana"))
+      (expect received :to-equal "b")))
+
+  (it "supports non-string values with labels"
+    (let ((received 'unset))
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (&rest _) "Two")))
+        (with-temp-buffer
+          (vui-render (vui-select :value 1
+                                  :options '((1 . "One") (2 . "Two"))
+                                  :on-change (lambda (v) (setq received v))))
+          (expect (buffer-string) :to-match "One")
+          (widget-apply (widget-at (point-min)) :notify)))
+      (expect received :to-equal 2)))
+
+  (it "passes plain string options through unchanged"
+    (let ((received 'unset))
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (&rest _) "banana")))
+        (with-temp-buffer
+          (vui-render (vui-select :value "apple"
+                                  :options '("apple" "banana")
+                                  :on-change (lambda (v) (setq received v))))
+          (widget-apply (widget-at (point-min)) :notify)))
+      (expect received :to-equal "banana"))))
 (describe "vui-render"
   (it "renders text to buffer"
     (with-temp-buffer

--- a/vui.el
+++ b/vui.el
@@ -947,9 +947,15 @@ Usage: (vui-checkbox :checked t :on-change (lambda (v) ...))"
 ARGS is a plist accepting:
   :value VALUE - current selection (or nil)
   :options OPTIONS - list of (value . label) cons cells or strings
-  :on-change FN - called with selected value
+  :on-change FN - called with the VALUE of the selected option
   :prompt STRING - minibuffer prompt (default \"Select: \")
   :key KEY - for reconciliation
+
+For (value . label) options, completion candidates and the button
+text show the LABELs, while :on-change receives the corresponding
+VALUE (which may be any Lisp object, e.g. a symbol or number).
+Labels should be unique; when they are not, the first matching
+option wins.  Plain options are their own label.
 
 Usage: (vui-select :value \"apple\"
                    :options \\='((\"apple\" . \"Apple\") (\"banana\" . \"Banana\"))
@@ -2905,6 +2911,18 @@ Handles :truncate and overflow:
            (options (vui-vnode-select-options vnode))
            (on-change (vui-vnode-select-on-change vnode))
            (prompt (vui-vnode-select-prompt vnode))
+           ;; Normalize options to (LABEL . VALUE); plain options serve
+           ;; as their own label
+           (normalized (mapcar (lambda (option)
+                                 (if (consp option)
+                                     (cons (cdr option) (car option))
+                                   (cons (if (stringp option)
+                                             option
+                                           (format "%s" option))
+                                         option)))
+                               options))
+           (current-label (or (car (rassoc value normalized))
+                              (and value (format "%s" value))))
            (captured-instance vui--current-instance)
            (captured-root vui--root-instance)
            ;; Capture current path for cursor tracking (reverse stack to get root-first order)
@@ -2915,10 +2933,15 @@ Handles :truncate and overflow:
                               :notify (lambda (&rest _)
                                         (let* ((vui--current-instance captured-instance)
                                                (vui--root-instance captured-root)
-                                               (choice (completing-read prompt options nil t nil nil value)))
-                                          (when wrapped-change
-                                            (funcall wrapped-change choice))))
-                              (format "%s" (or value "Select...")))))
+                                               (choice (completing-read prompt
+                                                                        (mapcar #'car normalized)
+                                                                        nil t nil nil
+                                                                        current-label))
+                                               (chosen (assoc choice normalized)))
+                                          (when (and wrapped-change chosen)
+                                            ;; Pass the option's VALUE, not its label
+                                            (funcall wrapped-change (cdr chosen)))))
+                              (format "%s" (or current-label "Select...")))))
         ;; Store path for cursor tracking
         (widget-put w :vui-path captured-path))))
 


### PR DESCRIPTION
The (value . label) options documented for vui-select were passed
raw to completing-read, which completes on alist cars: users
completed on the values, labels were never displayed anywhere, and
on-change received whatever string completing-read returned - so
non-string option values either broke completion or arrived as
strings.

Normalize options to (label . value) pairs internally: the button
text and completion candidates show the labels, and on-change
receives the selected option's value, which may be any Lisp object.
Plain options remain their own label. Duplicate labels resolve to
the first matching option.

