### PR TITLE
feat: add vui-use-context for namespace-clean context consumption

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-use-context= - Namespace-clean way to consume a context: =(vui-use-context NAME-context)= is equivalent to the =use-NAME= function that =vui-defcontext= generates. Packages should prefer it, since the unprefixed =use-NAME= hook pollutes the namespace; =use-NAME= remains generated for convenience in applications and personal configs. vui itself now consumes its collapsible-indent context this way.
 - =vui-unmount= - Explicitly unmount the instance mounted in a buffer. Runs the full teardown lifecycle for the whole tree (=:on-unmount= hooks, effect cleanups, =:on-mount= cleanup functions, async process and render timer cancellation) and erases the buffer. Previously there was no way to tear a mounted UI down, so timers and processes held by components leaked.
 - Async callbacks created via =vui-with-async-context= and =vui-async-callback= now also become no-ops when their component tree has been unmounted. Previously they only checked that the buffer was still alive, so a stale timer could re-render an unmounted tree into the buffer.
 - =vui-get-instance= - Return the root instance mounted in a buffer (defaults to the current buffer). Lets applications drive a mounted UI via =vui-rerender= / =vui-update= / =vui-update-props= without maintaining their own buffer-to-instance storage (#36).

--- a/README.org
+++ b/README.org
@@ -106,7 +106,7 @@ Result: A buffer with text "Count: 0" and a clickable button. Each click updates
 
 (vui-defcomponent themed-button (label)
   :render
-  (let ((theme (use-theme)))
+  (let ((theme (vui-use-context theme-context)))  ; or (use-theme)
     (vui-button label
                 :face (if (eq theme 'dark)
                           'custom-button-pressed

--- a/docs/guide/06-context.org
+++ b/docs/guide/06-context.org
@@ -62,7 +62,7 @@ Wrap your component tree with the provider:
 
 Everything inside the provider can access the context.
 
-* Consuming Context - =use-NAME=
+* Consuming Context - =vui-use-context= / =use-NAME=
 
 Use the auto-generated hook to access context:
 
@@ -75,6 +75,19 @@ Use the auto-generated hook to access context:
 #+end_src
 
 No more prop drilling! The component gets the user directly from context.
+
+The generated =use-NAME= function is convenient in applications and
+personal configs, but its =use-= prefix pollutes the namespace from a
+package's point of view. Packages should call =vui-use-context= on the
+context object instead - it is equivalent:
+
+#+begin_src elisp
+(vui-defcomponent user-info ()
+  :render
+  (let ((user (vui-use-context user-context)))
+    (vui-text (format "Logged in as: %s"
+                      (plist-get user :name)))))
+#+end_src
 
 * Complete Example
 

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -893,7 +893,7 @@ Define a context.
 Creates:
 - =NAME-context= - The context object
 - =NAME-provider= - Function to provide value
-- =use-NAME= - Hook to consume value
+- =use-NAME= - Convenience hook to consume value
 
 #+begin_src elisp
 (vui-defcontext theme 'light "Current UI theme.")
@@ -903,9 +903,28 @@ Creates:
   (vui-component 'my-app))
 
 ;; Consume (in component render)
+(let ((theme (vui-use-context theme-context)))
+  (vui-text (format "Theme: %s" theme)))
+
+;; Equivalent, via the generated hook
 (let ((theme (use-theme)))
   (vui-text (format "Theme: %s" theme)))
 #+end_src
+
+The =NAME=-derived symbols follow whatever prefix NAME carries, so
+packages should use a prefixed NAME (e.g. =my-pkg-theme=) and prefer
+=vui-use-context= over the unprefixed =use-NAME= hook.
+
+** vui-use-context
+
+#+begin_src elisp
+(vui-use-context CONTEXT) -> value
+#+end_src
+
+Return the current value of CONTEXT (a =NAME-context= object created by
+=vui-defcontext=). Searches the providers in scope at the current render
+position; returns the context's default value when no provider is found.
+Must be called during render.
 
 * Error Handling
 

--- a/test/vui-context-test.el
+++ b/test/vui-context-test.el
@@ -19,6 +19,51 @@
     (expect (fboundp 'use-test-ctx) :to-be-truthy)
     (expect (vui-context-default-value test-ctx-context) :to-equal 'default-value))
 
+  (it "consumes context via vui-use-context"
+    (vui-defcontext uc-theme 'light)
+    (let ((inside nil)
+          (outside nil))
+      (vui-defcomponent uc-consumer ()
+        :render (progn
+                  (setq inside (vui-use-context uc-theme-context))
+                  (vui-text "x")))
+      (vui-defcomponent uc-app ()
+        :render (uc-theme-provider 'dark
+                  (vui-component 'uc-consumer)))
+      (vui-defcomponent uc-bare ()
+        :render (progn
+                  (setq outside (vui-use-context uc-theme-context))
+                  (vui-text "y")))
+      (vui-mount (vui-component 'uc-app) "*test-uc1*")
+      (vui-mount (vui-component 'uc-bare) "*test-uc2*")
+      (unwind-protect
+          (progn
+            ;; Provided value inside a provider
+            (expect inside :to-equal 'dark)
+            ;; Default value without a provider
+            (expect outside :to-equal 'light))
+        (kill-buffer "*test-uc1*")
+        (kill-buffer "*test-uc2*"))))
+
+  (it "vui-use-context matches the generated use-NAME consumer"
+    (vui-defcontext uc-pair 'fallback)
+    (let ((via-generic nil)
+          (via-generated nil))
+      (vui-defcomponent uc-pair-consumer ()
+        :render (progn
+                  (setq via-generic (vui-use-context uc-pair-context))
+                  (setq via-generated (use-uc-pair))
+                  (vui-text "z")))
+      (vui-defcomponent uc-pair-app ()
+        :render (uc-pair-provider 42
+                  (vui-component 'uc-pair-consumer)))
+      (vui-mount (vui-component 'uc-pair-app) "*test-uc3*")
+      (unwind-protect
+          (progn
+            (expect via-generic :to-equal 42)
+            (expect via-generated :to-equal 42))
+        (kill-buffer "*test-uc3*"))))
+
   (it "returns default value when no provider"
     (vui-defcontext theme 'light)
     (let ((captured-theme nil))

--- a/vui-components.el
+++ b/vui-components.el
@@ -213,7 +213,7 @@ INITIALLY-EXPANDED sets initial state for uncontrolled mode."
          (indicator (if is-expanded exp-ind col-ind))
          ;; Indentation: own indent + accumulated from parent
          (own-indent (or indent 2))
-         (parent-indent (use-vui-collapsible-indent))
+         (parent-indent (vui-use-context vui-collapsible-indent-context))
          (total-indent (+ parent-indent own-indent)))
     (vui-fragment
      ;; Header - plain clickable text (no indent - inherits from parent)

--- a/vui.el
+++ b/vui.el
@@ -1612,7 +1612,15 @@ Called from within a component's render function."
 Creates:
 - `NAME-context': The context object
 - `NAME-provider': Function to create a provider vnode
-- `use-NAME': Function to consume the context value
+- `use-NAME': Convenience function to consume the context value
+
+The symbols derived from NAME alone (`NAME-context', `NAME-provider')
+follow whatever prefix NAME carries, so packages should use a
+prefixed NAME (e.g. `my-pkg-theme').  The generated `use-NAME'
+consumer is convenient in applications and personal configs, but its
+`use-' prefix pollutes the namespace from a package's point of view;
+packages should prefer calling `vui-use-context' on `NAME-context'
+instead.
 
 Example:
   (vui-defcontext theme \\='light \"The current UI theme.\")
@@ -1621,7 +1629,9 @@ Example:
   (theme-provider \\='dark
     (vui-component \\='my-button))
 
-  ;; In my-button:
+  ;; In my-button - either of:
+  (let ((theme (vui-use-context theme-context)))
+    (vui-text (format \"Theme: %s\" theme)))
   (let ((theme (use-theme)))
     (vui-text (format \"Theme: %s\" theme)))
 
@@ -1662,6 +1672,25 @@ Returns `default-value' if no provider found."
                when (eq (vui-context-binding-context binding) context)
                return (vui-context-binding-value binding))
       (vui-context-default-value context)))
+
+(defun vui-use-context (context)
+  "Return the current value of CONTEXT.
+CONTEXT is a context object, i.e. the NAME-context variable defined
+by `vui-defcontext'.  Searches the providers in scope at the current
+render position; returns the context's default value when no
+provider is found.
+
+This is the namespace-clean way to consume a context - equivalent to
+the generated `use-NAME' function:
+
+  (vui-defcontext my-pkg-theme \\='light)
+
+  ;; In a component render:
+  (vui-use-context my-pkg-theme-context)
+
+Must be called during render (inside a component's :render form or a
+provider's children)."
+  (vui--consume-context context))
 
 ;;; Memoized Callbacks
 


### PR DESCRIPTION
vui-defcontext generates an unprefixed use-NAME consumer, which is
convenient in applications but pollutes the namespace from a
package's point of view - vui itself shipped
use-vui-collapsible-indent. There was no prefixed way to read a
context value.

Expose vui-use-context: (vui-use-context NAME-context) is equivalent
to the generated (use-NAME). The use-NAME hook is still generated for
convenience; docs now steer packages toward vui-use-context and
prefixed context names. vui-components now consumes its
collapsible-indent context through the new function.

