### PR TITLE
docs: add third-party projects to Built with VUI list

### DIFF
--- a/README.org
+++ b/README.org
@@ -404,6 +404,11 @@ Contributions welcome! Please:
 - [[https://github.com/d12frosted/vulpea-ui][d12frosted/vulpea-ui]] — Sidebar UI for vulpea notes
 - [[https://github.com/d12frosted/vulpea-journal][d12frosted/vulpea-journal]] — Journaling system with calendar widgets
 - [[https://github.com/d12frosted/brb][d12frosted/brb]] — Barberry Garden management system
+- [[https://github.com/ahyatt/ekg][ahyatt/ekg]] — The Emacs knowledge graph, app for notes and structured data
+- [[https://github.com/ahyatt/emacs-bluesky][ahyatt/emacs-bluesky]] — Bluesky client for Emacs
+- [[https://github.com/ChristianTietze/beads.el][ChristianTietze/beads.el]] — Emacs interface to the Beads issue tracking system
+- [[https://github.com/r0man/beads.el][r0man/beads.el]] — Emacs mode for the Beads issue tracker (independent client)
+- [[https://github.com/r0man/gastown.el][r0man/gastown.el]] — Emacs mode for the Gastown agent orchestrator
 - [[https://github.com/zonuexe/unicode-inspector.el][zonuexe/unicode-inspector.el]] — Interactive Unicode character inspector
 - [[https://github.com/zonuexe/eijiro-search.el][zonuexe/eijiro-search.el]] — Interactive English-Japanese dictionary viewer
 

--- a/README.org
+++ b/README.org
@@ -169,6 +169,10 @@ For those curious about implementation details:
 - [[https://www.d12frosted.io/posts/2025-12-14-implicit-identity-call-order][Implicit Identity]] — How hooks use call order as implicit identity
 - [[https://www.d12frosted.io/posts/2025-12-16-cursor-preservation-buffer-rewrite][Cursor Preservation]] — Preserving cursor position across buffer rewrites
 
+Videos:
+
+- [[https://www.youtube.com/watch?v=7H3Lvo9LCvs][Declarative UIs in Emacs with vui.el]] — System Crafters Live! stream exploring vui.el
+
 * Examples
 
 See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:


### PR DESCRIPTION
Adds recently discovered third-party adopters to the *Built with VUI* section of the README:

- [ahyatt/ekg](https://github.com/ahyatt/ekg) — the Emacs knowledge graph
- [ahyatt/emacs-bluesky](https://github.com/ahyatt/emacs-bluesky) — Bluesky client for Emacs
- [ChristianTietze/beads.el](https://github.com/ChristianTietze/beads.el) and [r0man/beads.el](https://github.com/r0man/beads.el) — two independent Emacs clients for the Beads issue tracker
- [r0man/gastown.el](https://github.com/r0man/gastown.el) — Emacs mode for the Gastown agent orchestrator

All of them require =vui= directly (found via GitHub code search).