### PR TITLE
feat: add vui-mount-inline for ephemeral UIs in existing buffers

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]], and this project adheres to [[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
 
+* Unreleased
+
+** Added
+
+- *Inline mounting* (#8): =vui-mount-inline= renders a component into a managed region at point (or a given position) inside an existing buffer, without taking the buffer over - the major mode and surrounding content are untouched, and a buffer can host any number of inline instances. State updates rewrite only the instance's region; region mutations are kept out of the undo history. =vui-unmount= now also accepts an instance and removes an inline instance's region while running the full teardown lifecycle (which also runs on buffer kill, and when =vui-mount= takes over a buffer that hosts inline instances). =vui-inline-instance-at= returns the inline instance at a position. Intended for ephemeral, disposable forms in interactive documents.
+
 * v1.1.0 - 2026-06-12
 
 ** Added

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -95,28 +95,84 @@ new tree renders.
 (vui-mount (vui-component 'my-app :title "Hello") "*my-app*")
 #+end_src
 
+** vui-mount-inline
+
+#+begin_src elisp
+(vui-mount-inline COMPONENT-VNODE &optional POSITION) -> instance
+#+end_src
+
+Mount a component inline at POSITION (default: point) in the current
+buffer, without taking the buffer over.
+
+Unlike =vui-mount=, the component renders into a managed region inside
+the existing buffer content: the buffer's major mode is left untouched,
+and a buffer can host any number of inline instances. State updates
+rewrite only the instance's region.
+
+The region is ephemeral UI, not document content: vui keeps its rewrites
+out of the undo history, and manual edits inside the region (outside of
+input fields) are overwritten by the next re-render. POSITION must not
+fall strictly inside another inline instance's region.
+
+Pass the returned instance to =vui-unmount= to dismiss the UI (teardown
+also runs automatically when the buffer is killed), or drive it with
+=vui-rerender= / =vui-update= / =vui-update-props=.
+
+#+begin_src elisp
+;; An ephemeral form that dismisses itself on submit
+(let ((form nil))
+  (setq form
+        (vui-mount-inline
+         (vui-component 'server-query-form
+           :on-submit (lambda (params)
+                        (vui-unmount form)
+                        (run-query params))))))
+#+end_src
+
+** vui-inline-instance-at
+
+#+begin_src elisp
+(vui-inline-instance-at &optional POSITION) -> instance or nil
+#+end_src
+
+Return the inline instance whose region contains POSITION (default:
+point) in the current buffer, or nil if there is none. Useful for
+commands like "dismiss the form at point":
+
+#+begin_src elisp
+(when-let* ((form (vui-inline-instance-at)))
+  (vui-unmount form))
+#+end_src
+
 ** vui-unmount
 
 #+begin_src elisp
-(vui-unmount &optional BUFFER) -> instance or nil
+(vui-unmount &optional BUFFER-OR-INSTANCE) -> instance or nil
 #+end_src
 
-Unmount the VUI instance mounted in BUFFER (default: current buffer).
+Unmount a VUI instance, running its full teardown lifecycle.
 
-Runs the full teardown lifecycle for every component in the tree:
+BUFFER-OR-INSTANCE selects what to unmount:
+- nil, a buffer, or a buffer name :: the instance mounted in that buffer
+  (default: current buffer) via =vui-mount=. The buffer's content is
+  erased, but the buffer itself is not killed.
+- an instance returned by =vui-mount-inline= :: its managed region is
+  removed from the host buffer; the rest of the buffer is untouched.
+- an instance returned by =vui-mount= :: same as passing its buffer.
+
+The teardown lifecycle runs for every component in the tree:
 =:on-unmount= hooks, effect cleanup functions, cleanup functions returned
 from =:on-mount=, and cancellation of pending async processes and deferred
-renders. The buffer's content is erased, but the buffer itself is not
-killed.
+renders.
 
 After unmounting, async callbacks created via =vui-with-async-context= or
 =vui-async-callback= that captured this tree become no-ops.
 
-- BUFFER :: Buffer object or buffer name (default: current buffer)
 - Returns :: The unmounted instance, or nil if nothing was mounted
 
 #+begin_src elisp
 (vui-unmount "*my-app*")
+(vui-unmount inline-form-instance)
 #+end_src
 
 ** vui-get-instance

--- a/test/vui-inline-test.el
+++ b/test/vui-inline-test.el
@@ -1,0 +1,246 @@
+;;; vui-inline-test.el --- Inline mounting tests for vui.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Tests for inline mounting (issue #8): vui-mount-inline,
+;; region-scoped re-rendering inside host buffers, vui-unmount on
+;; inline instances, and teardown integration.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+;; Helper to click buttons (widget.el push-buttons)
+(defun vui-inline-test--click-button-at (pos)
+  "Invoke the button widget at POS."
+  (let ((widget (widget-at pos)))
+    (when widget
+      (widget-apply widget :action))))
+
+(describe "vui-mount-inline"
+  (it "renders at point without taking over the buffer"
+    (with-temp-buffer
+      (text-mode)
+      (insert "HEAD\nTAIL")
+      (goto-char 6)                     ; before "TAIL"
+      (vui-defcomponent inline-hello ()
+        :render (vui-fragment (vui-text "[form]") (vui-newline)))
+      (let ((instance (vui-mount-inline (vui-component 'inline-hello))))
+        (expect (vui-instance-p instance) :to-be-truthy)
+        ;; Host mode and surrounding content untouched
+        (expect major-mode :to-be 'text-mode)
+        (expect (buffer-string) :to-equal "HEAD\n[form]\nTAIL"))))
+
+  (it "mounts at an explicit position"
+    (with-temp-buffer
+      (insert "HEAD\nTAIL")
+      (goto-char (point-max))           ; point elsewhere
+      (vui-defcomponent inline-positioned ()
+        :render (vui-text "<X>"))
+      (vui-mount-inline (vui-component 'inline-positioned) 6)
+      (expect (buffer-string) :to-equal "HEAD\n<X>TAIL")))
+
+  (it "runs on-mount and effects"
+    (with-temp-buffer
+      (insert "HOST")
+      (goto-char (point-max))
+      (let ((mounted nil)
+            (effect-ran nil))
+        (vui-defcomponent inline-lifecycle ()
+          :on-mount (setq mounted t)
+          :render (progn
+                    (vui-use-effect ()
+                      (setq effect-ran t)
+                      nil)
+                    (vui-text "x")))
+        (vui-mount-inline (vui-component 'inline-lifecycle))
+        (expect mounted :to-be t)
+        (expect effect-ran :to-be t))))
+
+  (it "rejects positions inside another inline instance"
+    (with-temp-buffer
+      (insert "HOST")
+      (goto-char (point-min))
+      (vui-defcomponent inline-host-a ()
+        :render (vui-text "[aaaa]"))
+      (vui-mount-inline (vui-component 'inline-host-a))
+      ;; Position 3 is strictly inside the [aaaa] region
+      (expect (vui-mount-inline (vui-component 'inline-host-a) 3)
+              :to-throw 'error)))
+
+  (it "finds instances by position with vui-inline-instance-at"
+    (with-temp-buffer
+      (insert "HEAD\nTAIL")
+      (vui-defcomponent inline-findable ()
+        :render (vui-text "[form]"))
+      (let ((instance (vui-mount-inline (vui-component 'inline-findable) 6)))
+        ;; Inside the region (positions 6..12 cover "[form]")
+        (expect (vui-inline-instance-at 8) :to-be instance)
+        ;; Outside the region
+        (expect (vui-inline-instance-at 2) :to-be nil)
+        (expect (vui-inline-instance-at (point-max)) :to-be nil)))))
+
+(describe "inline re-rendering"
+  (it "re-renders only its region on state updates"
+    (let ((vui-render-delay nil))
+      (with-temp-buffer
+        (insert "HEAD\nTAIL")
+        (goto-char 6)
+        (vui-defcomponent inline-counter ()
+          :state ((n 0))
+          :render (vui-fragment
+                   (vui-button (format "n=%d" n)
+                     :on-click (lambda () (vui-set-state :n (1+ n))))
+                   (vui-newline)))
+        (vui-mount-inline (vui-component 'inline-counter))
+        (expect (buffer-string) :to-equal "HEAD\n[n=0]\nTAIL")
+        (vui-inline-test--click-button-at 6)
+        (expect (buffer-string) :to-equal "HEAD\n[n=1]\nTAIL"))))
+
+  (it "supports multiple independent instances in one buffer"
+    (let ((vui-render-delay nil))
+      (with-temp-buffer
+        (insert "ONE\nTWO\n")
+        (vui-defcomponent inline-multi (tag)
+          :state ((n 0))
+          :render (vui-fragment
+                   (vui-button (format "%s=%d" tag n)
+                     :on-click (lambda () (vui-set-state :n (1+ n))))
+                   (vui-newline)))
+        ;; Mount bottom-most first so positions stay valid
+        (vui-mount-inline (vui-component 'inline-multi :tag "b") 9)
+        (vui-mount-inline (vui-component 'inline-multi :tag "a") 1)
+        (expect (buffer-string) :to-equal "[a=0]\nONE\nTWO\n[b=0]\n")
+        ;; Click the first form's button
+        (vui-inline-test--click-button-at 1)
+        (expect (buffer-string) :to-equal "[a=1]\nONE\nTWO\n[b=0]\n")
+        ;; Click the second form's button ("[b=0]\n" is the last 6 chars)
+        (vui-inline-test--click-button-at (- (point-max) 6))
+        (expect (buffer-string) :to-equal "[a=1]\nONE\nTWO\n[b=1]\n"))))
+
+  (it "preserves point outside the region across re-renders"
+    (with-temp-buffer
+      (insert "HEAD\nTAIL")
+      (vui-defcomponent inline-growing (wide)
+        :render (vui-text (if wide "[wiiiiide]" "[w]")))
+      (let ((instance (vui-mount-inline (vui-component 'inline-growing
+                                                       :wide nil)
+                                        6)))
+        ;; Put point on the "A" of TAIL, after the region
+        (goto-char (- (point-max) 3))
+        (expect (char-after) :to-equal ?A)
+        ;; Grow the region; point must stay on the same character
+        (vui-update instance '(:wide t))
+        (expect (char-after) :to-equal ?A))))
+
+  (it "keeps point inside a field across re-renders"
+    (with-temp-buffer
+      (insert "HOST\n")
+      (goto-char (point-max))
+      (vui-defcomponent inline-field-form ()
+        :render (vui-fragment
+                 (vui-text "Name: ")
+                 (vui-field :value "abc" :size 10)
+                 (vui-newline)))
+      (let ((instance (vui-mount-inline (vui-component 'inline-field-form))))
+        ;; Move point into the field
+        (let ((field (car widget-field-list)))
+          (goto-char (1+ (widget-field-start field))))
+        (vui-rerender instance)
+        (expect (widget-field-at (point)) :to-be-truthy))))
+
+  (it "does not accumulate field bookkeeping across re-renders"
+    (with-temp-buffer
+      (insert "HOST\n")
+      (goto-char (point-max))
+      (vui-defcomponent inline-one-field ()
+        :render (vui-field :value "x" :size 5 :key 'inline-f1))
+      (let ((instance (vui-mount-inline (vui-component 'inline-one-field))))
+        (vui-rerender instance)
+        (vui-rerender instance)
+        (vui-rerender instance)
+        (expect (length widget-field-list) :to-equal 1)
+        (expect (vui-field-value 'inline-f1) :to-equal "x")))))
+
+(describe "inline unmounting"
+  (it "vui-unmount removes the region and runs full teardown"
+    (with-temp-buffer
+      (insert "HEAD\nTAIL")
+      (let ((cleanups nil))
+        (vui-defcomponent inline-teardown ()
+          :on-mount (lambda () (push 'mount-cleanup cleanups))
+          :on-unmount (push 'unmounted cleanups)
+          :render (progn
+                    (vui-use-effect ()
+                      (lambda () (push 'effect-cleanup cleanups)))
+                    (vui-text "[form]")))
+        (let ((instance (vui-mount-inline (vui-component 'inline-teardown) 6)))
+          (expect (buffer-string) :to-equal "HEAD\n[form]TAIL")
+          (expect (vui-unmount instance) :to-be-truthy)
+          ;; Region removed, host intact
+          (expect (buffer-string) :to-equal "HEAD\nTAIL")
+          (expect cleanups :to-have-same-items-as
+                  '(mount-cleanup effect-cleanup unmounted))
+          ;; No longer registered
+          (expect (vui-inline-instance-at 6) :to-be nil)
+          ;; Unmounting again is a no-op
+          (expect (vui-unmount instance) :to-be nil)))))
+
+  (it "makes stale async callbacks no-ops after unmount"
+    (with-temp-buffer
+      (insert "HOST")
+      (goto-char (point-max))
+      (let ((body-ran nil))
+        (vui-defcomponent inline-stale ()
+          :state ((n 0))
+          :render (vui-text (format "[%d]" n)))
+        (let* ((instance (vui-mount-inline (vui-component 'inline-stale)))
+               (callback (let ((vui--current-instance instance)
+                               (vui--root-instance instance))
+                           (vui-with-async-context
+                            (setq body-ran t)
+                            (vui-set-state :n 99)))))
+          (vui-unmount instance)
+          (funcall callback)
+          (expect body-ran :to-be nil)
+          (expect (buffer-string) :to-equal "HOST")))))
+
+  (it "runs teardown when the host buffer is killed"
+    (let ((unmounted nil))
+      (vui-defcomponent inline-kill-test ()
+        :on-unmount (setq unmounted t)
+        :render (vui-text "[form]"))
+      (with-current-buffer (get-buffer-create "*test-inline-kill*")
+        (insert "HOST")
+        (goto-char (point-max))
+        (vui-mount-inline (vui-component 'inline-kill-test)))
+      (kill-buffer "*test-inline-kill*")
+      (expect unmounted :to-be t)))
+
+  (it "vui-mount tears down inline instances in the same buffer"
+    (let ((unmounted nil))
+      (vui-defcomponent inline-victim ()
+        :on-unmount (setq unmounted t)
+        :render (vui-text "[inline]"))
+      (vui-defcomponent full-app ()
+        :render (vui-text "FULL"))
+      (with-current-buffer (get-buffer-create "*test-inline-full*")
+        (insert "HOST")
+        (goto-char (point-max))
+        (vui-mount-inline (vui-component 'inline-victim)))
+      (unwind-protect
+          (progn
+            (vui-mount (vui-component 'full-app) "*test-inline-full*")
+            (expect unmounted :to-be t)
+            (expect (with-current-buffer "*test-inline-full*" (buffer-string))
+                    :to-equal "FULL")
+            (expect (with-current-buffer "*test-inline-full*"
+                      vui--inline-instances)
+                    :to-be nil))
+        (kill-buffer "*test-inline-full*")))))
+
+(provide 'vui-inline-test)
+;;; vui-inline-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -631,7 +631,9 @@ Maps boundary keys to caught errors.  Lazily initialized by
   prev-props  ; Props from previous render (for on-update)
   prev-state  ; State from previous render (for on-update)
   render-timer ; Pending deferred-render timer (only used on root instances)
-  boundary-errors) ; Hash of error-boundary key -> caught error (root instances)
+  boundary-errors ; Hash of error-boundary key -> caught error (root instances)
+  region-start ; Marker: start of managed region (inline instances only)
+  region-end)  ; Marker: end of managed region (inline instances only)
 
 ;; Registry of component definitions
 (defvar vui--component-registry (make-hash-table :test 'eq)
@@ -1241,6 +1243,11 @@ child vnodes and may appear anywhere in the plist."
 
 (defvar vui--root-instance nil
   "The root component instance for the current buffer.")
+
+(defvar-local vui--inline-instances nil
+  "Inline instances mounted in this buffer via `vui-mount-inline'.
+Unlike `vui--root-instance', a buffer can host any number of inline
+instances, each owning a region delimited by its markers.")
 
 (defvar vui--batch-depth 0
   "Current nesting depth of `vui-batch' calls.")
@@ -2063,49 +2070,113 @@ instead of overflowing the stack."
 
 (defun vui--rerender-instance (instance)
   "Re-render INSTANCE and update the buffer.
+For instances mounted via `vui-mount-inline', only the region they
+manage is rewritten; otherwise the whole buffer is re-rendered.
+
 When called while another render is already in progress (for
 example, from `vui-set-state' in a lifecycle hook or effect with
 `vui-render-delay' set to nil), the request is queued and runs after
 the in-progress render commits, instead of erasing the buffer
 mid-render."
-  (if vui--rendering-p
-      (cl-pushnew instance vui--queued-rerenders :test #'eq)
-    (let ((buffer (vui-instance-buffer instance)))
-      (when (and buffer (buffer-live-p buffer))
-        (with-current-buffer buffer
-          (let* ((inhibit-read-only t)
-                 (inhibit-redisplay t)  ; Prevent flicker
-                 (inhibit-modification-hooks t)  ; Prevent widget-after-change errors
-                 ;; Save widget-relative cursor position
-                 (cursor-info (vui--save-cursor-position))
-                 ;; Save viewport (window-start) for all windows showing this buffer
-                 (window-info (vui--save-window-starts buffer))
-                 (vui--root-instance instance)
-                 ;; Initialize render path for cursor tracking
-                 (vui--render-path nil)
-                 ;; Clear pending effects before render
-                 (vui--pending-effects nil))
-            ;; Clear widget tracking before re-render
-            (setq widget-field-list nil)
-            (setq widget-field-new nil)
-            ;; Remove only widget overlays, preserve others (like hl-line)
-            (vui--remove-widget-overlays)
-            (erase-buffer)
-            ;; Queue re-render requests (vui-set-state with nil delay)
-            ;; until commit and effects are done
-            (setq vui--rendering-p t)
-            (unwind-protect
-                (progn
+  (cond
+   (vui--rendering-p
+    (cl-pushnew instance vui--queued-rerenders :test #'eq))
+   ((vui--inline-p instance)
+    (vui--rerender-inline instance))
+   (t
+    (vui--rerender-buffer instance))))
+
+(defun vui--rerender-inline (instance)
+  "Re-render inline INSTANCE inside the region it manages.
+The host buffer outside the region is left untouched.  Region
+mutations are kept out of the undo history: the rendered UI is
+ephemeral chrome, not document content."
+  (let ((buffer (vui-instance-buffer instance))
+        (start (vui-instance-region-start instance))
+        (end (vui-instance-region-end instance)))
+    (when (and buffer (buffer-live-p buffer)
+               start (marker-position start))
+      (with-current-buffer buffer
+        (let* ((inhibit-read-only t)
+               (inhibit-redisplay t)
+               (inhibit-modification-hooks t)
+               ;; Managed UI text is not part of the document's history
+               (buffer-undo-list t)
+               (pos (marker-position start))
+               (end-pos (marker-position end))
+               ;; Only track the cursor when it is inside the region;
+               ;; positions outside adjust automatically
+               (cursor-info (when (and (>= (point) pos)
+                                       (<= (point) end-pos))
+                              (vui--save-cursor-position pos end-pos)))
+               (vui--root-instance instance)
+               (vui--render-path nil)
+               (vui--pending-effects nil))
+          ;; Queue re-render requests until commit and effects are done
+          (setq vui--rendering-p t)
+          (unwind-protect
+              (progn
+                (save-excursion
+                  (vui--remove-widget-overlays pos end-pos)
+                  (vui--forget-region-fields pos end-pos)
+                  (delete-region pos end-pos)
+                  (goto-char pos)
                   (vui--render-instance instance)
+                  ;; Reposition the markers around the fresh content:
+                  ;; START's insertion type made it advance past our
+                  ;; own insertions (so user edits stay outside), put
+                  ;; it back at the region's beginning
+                  (set-marker start pos)
+                  (set-marker end (point))
                   (widget-setup)
-                  (vui--setup-field-placeholders)
-                  ;; Restore cursor position
-                  (vui--restore-cursor-position cursor-info)
-                  ;; Restore viewport for all windows
-                  (vui--restore-window-starts window-info)
-                  ;; Run effects after commit
-                  (vui--run-pending-effects))
-              (setq vui--rendering-p nil))))
+                  (vui--setup-field-placeholders))
+                (when cursor-info
+                  (vui--restore-cursor-position cursor-info pos
+                                                (marker-position end)))
+                ;; Run effects after commit
+                (vui--run-pending-effects))
+            (setq vui--rendering-p nil))))
+      ;; Run any re-renders requested during render/effects
+      (vui--flush-queued-rerenders))))
+
+(defun vui--rerender-buffer (instance)
+  "Re-render INSTANCE as the root of its whole buffer."
+  (let ((buffer (vui-instance-buffer instance)))
+    (when (and buffer (buffer-live-p buffer))
+      (with-current-buffer buffer
+        (let* ((inhibit-read-only t)
+               (inhibit-redisplay t)  ; Prevent flicker
+               (inhibit-modification-hooks t)  ; Prevent widget-after-change errors
+               ;; Save widget-relative cursor position
+               (cursor-info (vui--save-cursor-position))
+               ;; Save viewport (window-start) for all windows showing this buffer
+               (window-info (vui--save-window-starts buffer))
+               (vui--root-instance instance)
+               ;; Initialize render path for cursor tracking
+               (vui--render-path nil)
+               ;; Clear pending effects before render
+               (vui--pending-effects nil))
+          ;; Clear widget tracking before re-render
+          (setq widget-field-list nil)
+          (setq widget-field-new nil)
+          ;; Remove only widget overlays, preserve others (like hl-line)
+          (vui--remove-widget-overlays)
+          (erase-buffer)
+          ;; Queue re-render requests (vui-set-state with nil delay)
+          ;; until commit and effects are done
+          (setq vui--rendering-p t)
+          (unwind-protect
+              (progn
+                (vui--render-instance instance)
+                (widget-setup)
+                (vui--setup-field-placeholders)
+                ;; Restore cursor position
+                (vui--restore-cursor-position cursor-info)
+                ;; Restore viewport for all windows
+                (vui--restore-window-starts window-info)
+                ;; Run effects after commit
+                (vui--run-pending-effects))
+            (setq vui--rendering-p nil)))
         ;; Run any re-renders requested during render/effects
         (vui--flush-queued-rerenders)))))
 
@@ -2285,6 +2356,24 @@ like hl-line."
               (overlay-get ov 'field)
               (overlay-get ov 'vui-placeholder))
       (delete-overlay ov))))
+
+(defun vui--inline-p (instance)
+  "Return non-nil if INSTANCE was mounted inline (owns a region)."
+  (and (vui-instance-region-start instance) t))
+
+(defun vui--forget-region-fields (start end)
+  "Drop field-widget bookkeeping for fields between START and END.
+Field widgets whose text is about to be deleted would otherwise
+linger in `widget-field-list' with collapsed bounds, confusing
+`widget-before-change' and `vui-field-value'.  Entries whose field
+no longer exists are dropped as well."
+  (let ((in-region-p
+         (lambda (widget)
+           (let ((field-start (widget-field-start widget)))
+             (or (null field-start)
+                 (and (>= field-start start) (<= field-start end)))))))
+    (setq widget-field-list (cl-remove-if in-region-p widget-field-list))
+    (setq widget-field-new (cl-remove-if in-region-p widget-field-new))))
 
 (defun vui--field-add-placeholder (widget)
   "Show WIDGET's placeholder while its field is empty.
@@ -3359,6 +3448,12 @@ Returns the root instance."
         ;; re-render the old UI over the new mount.
         (when vui--root-instance
           (vui--unmount-root vui--root-instance))
+        ;; A full mount owns the whole buffer: tear down inline
+        ;; instances too, since erasing destroys their regions
+        (when vui--inline-instances
+          (dolist (inline-instance vui--inline-instances)
+            (vui--unmount-root inline-instance))
+          (kill-local-variable 'vui--inline-instances))
         ;; Enable vui-mode (this also sets up the keymap hierarchy)
         (unless (derived-mode-p 'vui-mode)
           (vui-mode))
@@ -3389,6 +3484,80 @@ Returns the root instance."
     (switch-to-buffer buf)
     instance))
 
+(defun vui-mount-inline (component-vnode &optional position)
+  "Mount COMPONENT-VNODE inline at POSITION in the current buffer.
+
+Unlike `vui-mount', this does not take over the buffer: the
+component renders into a managed region at POSITION (default:
+point) inside the existing buffer content.  The buffer's major mode
+is left untouched, and a buffer can host any number of inline
+instances alongside its regular content.
+
+The region is ephemeral UI, not document content: vui rewrites it
+on every state update, keeps those rewrites out of the undo
+history, and removes the region when the instance is unmounted.
+Manual edits inside the region (outside of input fields) are
+overwritten by the next re-render.
+
+POSITION must not fall strictly inside another inline instance's
+region.
+
+Returns the instance.  Pass it to `vui-unmount' to dismiss the UI
+and run the full teardown lifecycle (which also happens
+automatically when the buffer is killed), or drive it with
+`vui-rerender' / `vui-update' / `vui-update-props'.
+
+Example - an ephemeral form that dismisses itself on submit:
+
+  (let* ((form nil))
+    (setq form
+          (vui-mount-inline
+           (vui-component \\='server-query-form
+             :on-submit (lambda (params)
+                          (vui-unmount form)
+                          (run-query params))))))"
+  (let ((pos (or position (point))))
+    (when (cl-find-if (lambda (instance)
+                        (let ((s (vui-instance-region-start instance))
+                              (e (vui-instance-region-end instance)))
+                          (and s e (marker-position s)
+                               (> pos (marker-position s))
+                               (< pos (marker-position e)))))
+                      vui--inline-instances)
+      (error "Position %d is inside an existing inline VUI instance" pos))
+    (let ((instance (vui--create-instance component-vnode nil))
+          (start (make-marker))
+          (end (make-marker)))
+      (setf (vui-instance-buffer instance) (current-buffer))
+      (set-marker start pos)
+      (set-marker end pos)
+      ;; Text typed by the user at the boundaries stays outside the
+      ;; region: START advances past insertions at its position, END
+      ;; stays before them.  Render itself repositions both markers
+      ;; explicitly.
+      (set-marker-insertion-type start t)
+      (set-marker-insertion-type end nil)
+      (setf (vui-instance-region-start instance) start)
+      (setf (vui-instance-region-end instance) end)
+      (push instance vui--inline-instances)
+      ;; Release component resources when the buffer is killed
+      (add-hook 'kill-buffer-hook #'vui--teardown-on-kill nil t)
+      (vui--rerender-instance instance)
+      instance)))
+
+(defun vui-inline-instance-at (&optional position)
+  "Return the inline VUI instance whose region contains POSITION.
+POSITION defaults to point.  Returns nil when POSITION is not inside
+any region mounted via `vui-mount-inline' in the current buffer."
+  (let ((pos (or position (point))))
+    (cl-find-if (lambda (instance)
+                  (let ((s (vui-instance-region-start instance))
+                        (e (vui-instance-region-end instance)))
+                    (and s e (marker-position s)
+                         (>= pos (marker-position s))
+                         (<= pos (marker-position e)))))
+                vui--inline-instances)))
+
 (defun vui-get-instance (&optional buffer)
   "Return the root component instance mounted in BUFFER.
 BUFFER defaults to the current buffer and may be a buffer object or
@@ -3405,40 +3574,85 @@ Use this together with `vui-rerender', `vui-update', and
       (buffer-local-value 'vui--root-instance buf))))
 
 (defun vui--teardown-on-kill ()
-  "Run the unmount lifecycle for the current buffer's root instance.
-Installed buffer-locally on `kill-buffer-hook' by `vui-mount' so
-components release their resources (timers, processes, subscriptions)
-when the buffer is killed."
+  "Run the unmount lifecycle for this buffer's mounted instances.
+Installed buffer-locally on `kill-buffer-hook' by `vui-mount' and
+`vui-mount-inline' so components release their resources (timers,
+processes, subscriptions) when the buffer is killed."
   (when vui--root-instance
     (vui--unmount-root vui--root-instance)
-    (kill-local-variable 'vui--root-instance)))
+    (kill-local-variable 'vui--root-instance))
+  (when vui--inline-instances
+    (dolist (instance vui--inline-instances)
+      (vui--unmount-root instance))
+    (kill-local-variable 'vui--inline-instances)))
 
-(defun vui-unmount (&optional buffer)
-  "Unmount the VUI instance mounted in BUFFER (default: current buffer).
-BUFFER may be a buffer object or a buffer name.
+(defun vui--unmount-inline (instance)
+  "Tear down inline INSTANCE and remove its region from the buffer.
+Returns INSTANCE, or nil if it was already unmounted."
+  (when (vui-instance-buffer instance)
+    (let ((buffer (vui-instance-buffer instance))
+          (start (vui-instance-region-start instance))
+          (end (vui-instance-region-end instance)))
+      ;; Run cleanups and detach first, so the tree cannot re-render
+      ;; into the region we are about to delete
+      (vui--unmount-root instance)
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (setq vui--inline-instances (delq instance vui--inline-instances))
+          (when (and start (marker-position start))
+            (let ((inhibit-read-only t)
+                  (inhibit-modification-hooks t)
+                  ;; Managed UI text is not part of the undo history
+                  (buffer-undo-list t)
+                  (pos (marker-position start))
+                  (end-pos (marker-position end)))
+              (vui--remove-widget-overlays pos end-pos)
+              (vui--forget-region-fields pos end-pos)
+              (delete-region pos end-pos)))))
+      (when start (set-marker start nil))
+      (when end (set-marker end nil))
+      (setf (vui-instance-region-start instance) nil)
+      (setf (vui-instance-region-end instance) nil)
+      instance)))
 
-Runs the full teardown lifecycle for every component in the tree:
+(defun vui-unmount (&optional buffer-or-instance)
+  "Unmount a VUI instance, running its full teardown lifecycle.
+
+BUFFER-OR-INSTANCE selects what to unmount:
+- nil, a buffer, or a buffer name: the instance mounted in that
+  buffer (default: current buffer) via `vui-mount'.  The buffer's
+  content is erased, but the buffer itself is not killed.
+- an instance returned by `vui-mount-inline': its managed region is
+  removed from the host buffer; the rest of the buffer is untouched.
+- an instance returned by `vui-mount': same as passing its buffer.
+
+The teardown lifecycle runs for every component in the tree:
 on-unmount hooks, effect cleanup functions, cleanup functions
 returned from on-mount, and cancellation of pending async processes
-and deferred renders.  The buffer's content is erased, but the
-buffer itself is not killed.
+and deferred renders.
 
 After unmounting, async callbacks created via
 `vui-with-async-context' or `vui-async-callback' that captured this
 tree become no-ops.
 
-Returns the unmounted instance, or nil if BUFFER does not exist or
-has no mounted instance."
-  (when-let* ((instance (vui-get-instance buffer)))
-    (let ((buf (vui-instance-buffer instance)))
-      (vui--unmount-root instance)
-      (when (buffer-live-p buf)
-        (with-current-buffer buf
-          (kill-local-variable 'vui--root-instance)
-          (let ((inhibit-read-only t))
-            (remove-overlays)
-            (erase-buffer)))))
-    instance))
+Returns the unmounted instance, or nil if nothing was mounted."
+  (cond
+   ((vui-instance-p buffer-or-instance)
+    (if (vui--inline-p buffer-or-instance)
+        (vui--unmount-inline buffer-or-instance)
+      (when-let* ((buffer (vui-instance-buffer buffer-or-instance)))
+        (vui-unmount buffer))))
+   (t
+    (when-let* ((instance (vui-get-instance buffer-or-instance)))
+      (let ((buf (vui-instance-buffer instance)))
+        (vui--unmount-root instance)
+        (when (buffer-live-p buf)
+          (with-current-buffer buf
+            (kill-local-variable 'vui--root-instance)
+            (let ((inhibit-read-only t))
+              (remove-overlays)
+              (erase-buffer)))))
+      instance))))
 
 (provide 'vui)
 ;;; vui.el ends here


### PR DESCRIPTION
vui could only take over a whole dedicated buffer via vui-mount,
which rules out the interactive-document use case: a disposable,
validated form expanding at point inside an org file or any host
buffer, then vanishing on submit.

vui-mount-inline renders a component into a managed region at point
(or a given position) inside the existing buffer content. The host
buffer's major mode and surrounding text are untouched, and a buffer
can host any number of inline instances. The region is delimited by
markers whose insertion types keep user edits at the boundaries
outside the region, while renders reposition them explicitly.

State updates flow through the existing per-root scheduling but
rewrite only the instance's region: widget overlays, field
bookkeeping, and cursor restoration are all scoped to it, so host
content and sibling inline instances are never disturbed. Region
mutations stay out of the undo history - the rendered UI is
ephemeral chrome, not document content.

vui-unmount now also accepts an instance: for inline instances it
removes the region and runs the full teardown lifecycle. Teardown
also runs when the host buffer is killed and when vui-mount takes
over a buffer hosting inline instances. vui-inline-instance-at
returns the instance at a position, for commands like dismiss-form-
at-point. Mounting strictly inside another instance's region signals
an error.

Closes #8

