### PR TITLE
docs: add inline mounting guide and runnable example

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,6 +25,7 @@ The API is stable and used in [[#built-with-vui][real-world projects]].
 - *Hooks* — vui-use-effect, vui-use-ref, vui-use-memo, vui-use-callback
 - *Context* — Share data across component trees without prop drilling
 - *Layout Primitives* — hstack, vstack, box, table, list
+- *Inline Mounting* — Ephemeral forms inside existing buffers, without taking them over
 - *Error Boundaries* — Graceful error handling with fallback UI
 - *Developer Tools* — Component inspector, timing profiler, debug logging
 
@@ -150,6 +151,7 @@ Clone this repository and add to your load-path:
 | [[file:docs/guide/08-error-handling.org][Error Handling]]  | Error boundaries                 |
 | [[file:docs/guide/09-performance.org][Performance]]     | Optimization techniques          |
 | [[file:docs/guide/10-dev-tools.org][Developer Tools]] | Inspector, profiler, debugging   |
+| [[file:docs/guide/11-inline.org][Inline Mounting]] | Ephemeral forms in existing buffers |
 | [[file:docs/reference/api.org][API Reference]]   | Complete function reference      |
 
 * Deep Dives
@@ -185,6 +187,7 @@ See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:
 - [[file:docs/examples/06-collapsible.el][Collapsible]] — Expandable/collapsible sections, FAQ style, nested sections
 - [[file:docs/examples/07-semantic-text.el][Semantic Text]] — Headings, emphasis, status messages with customizable faces
 - [[file:docs/examples/08-typed-fields.el][Typed Fields]] — Integer/float/symbol input with validation, shopping cart, forms
+- [[file:docs/examples/09-inline-form.el][Inline Forms]] — Ephemeral, validated forms expanding at point in existing buffers
 
 * Available Components
 

--- a/docs/examples/09-inline-form.el
+++ b/docs/examples/09-inline-form.el
@@ -1,0 +1,104 @@
+;;; 09-inline-form.el --- Ephemeral inline forms with vui.el -*- lexical-binding: t -*-
+
+;; This file demonstrates inline mounting (vui-mount-inline): disposable
+;; forms that expand inside an existing buffer, collect validated input,
+;; and vanish on submit - without taking the buffer over.
+;;
+;; Evaluate the entire buffer with M-x eval-buffer, then run
+;; M-x vui-example-inline-document to open a demo "document". Click the
+;; trigger button to expand a query form at point; submit or cancel to
+;; dismiss it. Note that the buffer keeps its own major mode and content
+;; the whole time.
+
+;;; Code:
+
+(require 'vui)
+(require 'vui-components)
+
+;;; Example 1: A parameterized query form
+;;
+;; The form collects a host name and a row limit, validates the limit as
+;; an integer in range, and reports the parameters on submit. ON-SUBMIT
+;; and ON-CANCEL are passed in as props; the *caller* owns the mounted
+;; instance and decides how to dismiss it.
+
+(vui-defcomponent inline-query-form (on-submit on-cancel)
+  :state ((host "localhost")
+          (limit 10))
+  :render
+  (vui-vstack
+   (vui-text "── query parameters ──" :face 'shadow)
+   (vui-hstack
+    (vui-text "Host: ")
+    (vui-field :value host
+               :size 16
+               :placeholder "hostname"
+               :on-change (lambda (v) (vui-set-state :host v))))
+   (vui-hstack
+    (vui-text "Limit:")
+    (vui-integer-field :value limit
+                       :min 1 :max 100
+                       :size 5
+                       :show-error 'inline
+                       :on-change (lambda (n) (vui-set-state :limit n))))
+   (vui-hstack
+    (vui-button "Run query"
+      :on-click (lambda () (funcall on-submit host limit)))
+    (vui-button "Cancel"
+      :on-click (lambda () (funcall on-cancel))))
+   (vui-text "──────────────────────" :face 'shadow)))
+
+(defun vui-example-query-at-point ()
+  "Expand an ephemeral query form at point in the current buffer."
+  (interactive)
+  (let ((form nil))
+    (setq form
+          (vui-mount-inline
+           (vui-component 'inline-query-form
+             :on-submit (lambda (host limit)
+                          (vui-unmount form)
+                          (message "Querying %s (limit %d)..." host limit))
+             :on-cancel (lambda ()
+                          (vui-unmount form)
+                          (message "Cancelled")))))))
+
+;;; Example 2: A host "document" with a trigger
+;;
+;; Simulates the interactive-document use case: a plain text-mode buffer
+;; whose content is ordinary text, plus a command that expands the form
+;; right where you need it.
+
+(defun vui-example-inline-document ()
+  "Open a demo document for inline forms."
+  (interactive)
+  (let ((buf (get-buffer-create "*vui-inline-demo*")))
+    (with-current-buffer buf
+      (erase-buffer)
+      (text-mode)
+      (insert "# Server Runbook\n"
+              "\n"
+              "This is an ordinary text buffer - vui does not own it.\n"
+              "\n"
+              "To inspect a server, place point on the empty line below\n"
+              "and run M-x vui-example-query-at-point:\n"
+              "\n"
+              "\n"
+              "The form expands at point, validates its input, and\n"
+              "disappears when submitted or cancelled.\n")
+      (goto-char (point-min))
+      (forward-line 7))
+    (pop-to-buffer buf)))
+
+;;; Example 3: Dismissing the form at point
+;;
+;; A reusable command for a keybinding such as C-c C-k.
+
+(defun vui-example-dismiss-form-at-point ()
+  "Dismiss the inline vui form at point, if any."
+  (interactive)
+  (if-let* ((form (vui-inline-instance-at)))
+      (vui-unmount form)
+    (message "No form at point")))
+
+(provide '09-inline-form)
+;;; 09-inline-form.el ends here

--- a/docs/guide/11-inline.org
+++ b/docs/guide/11-inline.org
@@ -1,0 +1,123 @@
+#+TITLE: Inline Mounting
+#+AUTHOR: vui.el Documentation
+#+OPTIONS: toc:2 num:t
+
+=vui-mount= takes over a dedicated buffer. Inline mounting does the
+opposite: it renders a component *into* an existing buffer at point,
+leaving the buffer's major mode and surrounding content untouched. It is
+designed for ephemeral, disposable UIs - a parameter form that expands
+inside a document, collects validated input, and vanishes on submit.
+
+* Quick Example
+
+#+begin_src elisp
+(vui-defcomponent confirm-form (on-answer)
+  :render
+  (vui-fragment
+   (vui-text "Proceed? ")
+   (vui-button "Yes" :on-click (lambda () (funcall on-answer t)))
+   (vui-space)
+   (vui-button "No" :on-click (lambda () (funcall on-answer nil)))
+   (vui-newline)))
+
+(defun my-confirm-at-point (callback)
+  "Expand a confirm form at point; dismiss it once answered."
+  (let ((form nil))
+    (setq form
+          (vui-mount-inline
+           (vui-component 'confirm-form
+             :on-answer (lambda (answer)
+                          (vui-unmount form)
+                          (funcall callback answer)))))))
+#+end_src
+
+Calling =my-confirm-at-point= in any buffer - an org file, a log, a
+REPL - inserts the form at point. Clicking an answer removes the form
+and leaves the buffer exactly as it was.
+
+* How It Works
+
+=vui-mount-inline= creates a *managed region* delimited by markers at the
+mount position. Everything else works like a regular mount:
+
+- The component tree has state, hooks, context, and lifecycle exactly as
+  in dedicated buffers.
+- State updates re-render through the usual scheduling, but only the
+  managed region is rewritten. Host content and other inline instances
+  are never disturbed.
+- A buffer can host any number of inline instances; each re-renders
+  independently.
+
+#+begin_src elisp
+(vui-mount-inline COMPONENT-VNODE &optional POSITION) ; -> instance
+#+end_src
+
+POSITION defaults to point and must not fall strictly inside another
+inline instance's region.
+
+* Dismissing
+
+Pass the instance to =vui-unmount=:
+
+#+begin_src elisp
+(vui-unmount form-instance)
+#+end_src
+
+This removes the region from the buffer and runs the full teardown
+lifecycle: =:on-unmount= hooks, effect cleanups, =:on-mount= cleanup
+functions, and cancellation of pending async work. The same teardown
+runs automatically when the host buffer is killed, and when =vui-mount=
+takes over a buffer that hosts inline instances.
+
+To find the instance at point - say, for a "dismiss form" keybinding:
+
+#+begin_src elisp
+(defun my-dismiss-form-at-point ()
+  (interactive)
+  (if-let* ((form (vui-inline-instance-at)))
+      (vui-unmount form)
+    (message "No form at point")))
+#+end_src
+
+* The Ephemeral Form Pattern
+
+The flow from the motivating use case (interactive documents):
+
+1. A trigger - a button, link, or command - calls =vui-mount-inline= at
+   point, capturing the returned instance.
+2. The form collects input with full vui validation (=vui-typed-field=
+   et al.).
+3. The submit handler calls =vui-unmount= on the instance, then acts on
+   the collected values - inserting results into the document, running
+   a process, opening a buffer.
+
+See =docs/examples/09-inline-form.el= for a complete, runnable
+walkthrough of this pattern.
+
+* Caveats
+
+Inline regions are ephemeral UI chrome, not document content:
+
+- *Undo*: vui keeps region rewrites out of the undo history. You cannot
+  undo a form back into existence, and undoing host-buffer edits made
+  while a form is mounted may restore positions inaccurately if the
+  form changed size in between. Keep forms short-lived.
+- *Manual edits*: text you type inside the region (outside of input
+  fields) is overwritten by the next re-render. Text typed at the
+  region's boundaries stays outside it.
+- *Saving*: if the host buffer visits a file, a mounted form's text
+  would be saved like any other text. Dismiss forms before saving, or
+  mount them in non-file buffers.
+- *Keybindings*: the host buffer's major mode stays active, so =TAB= /
+  =RET= work on the widgets themselves (fields and buttons carry their
+  own keymaps), but vui-mode conveniences like =q= and =g= are not
+  installed.
+
+* API Summary
+
+| Function                  | Description                                |
+|---------------------------+--------------------------------------------|
+| =vui-mount-inline=        | Mount a component at point/position        |
+| =vui-unmount=             | Dismiss (also accepts inline instances)    |
+| =vui-inline-instance-at=  | Find the inline instance at a position     |
+| =vui-rerender= / =vui-update= / =vui-update-props= | Drive a mounted instance |


### PR DESCRIPTION
Guide covering the ephemeral form pattern, dismissal, and the
caveats that follow from regions being UI chrome rather than
document content (undo, manual edits, saving, keybindings). The
runnable example walks through a parameterized query form expanding
at point inside a plain text-mode document.

