### PR TITLE
feat: add vui-region for container-level face and keymap styling

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-region= - styling wrapper that applies =:face= and =:keymap= to its children's whole extent (#41). The face is layered beneath the children's own faces, so child faces win while separators, padding, and indentation inserted by nested layout containers get styled too. The keymap cascades: nested regions' and buttons' own keymaps win for keys they define, unbound keys fall through to the region's map, and from there to the buffer's usual keymaps; buttons keep their default =RET= / =TAB= behavior and input fields are untouched.
 - *Inline mounting* (#8): =vui-mount-inline= renders a component into a managed region at point (or a given position) inside an existing buffer, without taking the buffer over - the major mode and surrounding content are untouched, and a buffer can host any number of inline instances. State updates rewrite only the instance's region; region mutations are kept out of the undo history. =vui-unmount= now also accepts an instance and removes an inline instance's region while running the full teardown lifecycle (which also runs on buffer kill, and when =vui-mount= takes over a buffer that hosts inline instances). =vui-inline-instance-at= returns the inline instance at a position. Intended for ephemeral, disposable forms in interactive documents.
 
 * v1.1.0 - 2026-06-12

--- a/docs/reference/api.org
+++ b/docs/reference/api.org
@@ -529,6 +529,39 @@ Fixed-width container for CHILD.
 (vui-box (vui-text "Centered") :width 30 :align :center)
 #+end_src
 
+** vui-region
+
+#+begin_src elisp
+(vui-region [OPTIONS...] CHILDREN...) -> vnode
+#+end_src
+
+Styling wrapper: apply a face and/or keymap to the children's whole
+extent, without affecting layout.
+
+| Property  | Type   | Description                                  |
+|-----------+--------+----------------------------------------------|
+| =:face=   | face   | Applied beneath the children's own faces     |
+| =:keymap= | keymap | Cascades beneath the children's own keymaps  |
+| =:key=    | any    | Reconciliation key                           |
+
+The face is layered with the lowest priority: children that set their
+own faces keep them, while plain text - including separators, padding,
+and indentation inserted by nested layout containers - gets the region
+face. Useful for row highlighting and panel backgrounds.
+
+The keymap cascades innermost-first: a nested region's or a button's
+own keymap wins for keys it defines, unbound keys fall through to the
+region's map, then to the buffer's usual keymaps. Buttons keep their
+default =RET= / =TAB= behavior, and input fields keep their own keymap.
+
+#+begin_src elisp
+;; Highlight a selected row and give it row-level bindings
+(vui-region :face 'highlight :keymap my-row-map
+  (vui-hstack
+   (vui-text "item")
+   (vui-button "open" :on-click #'my-open)))
+#+end_src
+
 ** vui-table
 
 #+begin_src elisp

--- a/test/vui-layout-test.el
+++ b/test/vui-layout-test.el
@@ -271,6 +271,97 @@ Buttons are widget.el push-buttons, so we use widget-apply."
               (expect clicked :to-be-truthy))
           (kill-buffer "*test-box-btn*"))))))
 
+(defun vui-layout-test--faces-at (pos)
+  "Return the face property at POS as a list."
+  (let ((face (get-text-property pos 'face)))
+    (if (listp face) face (list face))))
+
+(describe "vui-region"
+  (it "applies face to plain content"
+    (with-temp-buffer
+      (vui-render (vui-region :face 'shadow
+                    (vui-text "ab")))
+      (expect (vui-layout-test--faces-at 1) :to-contain 'shadow)
+      (expect (vui-layout-test--faces-at 2) :to-contain 'shadow)))
+
+  (it "applies face beneath children's own faces"
+    (with-temp-buffer
+      (vui-render (vui-region :face 'shadow
+                    (vui-text "p")
+                    (vui-text "b" :face 'bold)))
+      ;; Plain child gets only the region face
+      (expect (vui-layout-test--faces-at 1) :to-contain 'shadow)
+      ;; Styled child keeps its face with higher priority
+      (let ((faces (vui-layout-test--faces-at 2)))
+        (expect faces :to-contain 'bold)
+        (expect faces :to-contain 'shadow)
+        (expect (< (cl-position 'bold faces) (cl-position 'shadow faces))
+                :to-be-truthy))))
+
+  (it "covers whitespace inserted by nested layout containers"
+    (with-temp-buffer
+      (vui-render (vui-region :face 'shadow
+                    (vui-hstack (vui-text "a") (vui-text "b"))))
+      ;; Position 2 is the separator space inserted by the hstack
+      (expect (buffer-string) :to-equal "a b")
+      (expect (vui-layout-test--faces-at 2) :to-contain 'shadow)))
+
+  (it "renders nothing for empty children"
+    (with-temp-buffer
+      (vui-render (vui-region :face 'shadow))
+      (expect (buffer-string) :to-equal "")))
+
+  (it "applies keymap to plain text"
+    (with-temp-buffer
+      (let ((km (make-sparse-keymap)))
+        (vui-render (vui-region :keymap km
+                      (vui-text "ab")))
+        (expect (get-text-property 1 'keymap) :to-be km))))
+
+  (it "cascades nested region keymaps innermost-first"
+    (with-temp-buffer
+      (let ((outer (make-sparse-keymap))
+            (inner (make-sparse-keymap)))
+        (define-key outer (kbd "a") #'forward-char)
+        (define-key outer (kbd "b") #'backward-char)
+        (define-key inner (kbd "a") #'ignore)
+        (vui-render (vui-region :keymap outer
+                      (vui-region :keymap inner
+                        (vui-text "x"))))
+        (let ((map (get-text-property 1 'keymap)))
+          ;; Inner binding wins for "a"
+          (expect (lookup-key map (kbd "a")) :to-be 'ignore)
+          ;; Unbound keys fall through to the outer map
+          (expect (lookup-key map (kbd "b")) :to-be 'backward-char)))))
+
+  (it "composes with a button's keymap, button bindings winning"
+    (with-temp-buffer
+      (let ((container-km (make-sparse-keymap))
+            (button-km (make-sparse-keymap)))
+        (define-key container-km (kbd "x") #'forward-char)
+        (define-key container-km (kbd "y") #'backward-char)
+        (define-key button-km (kbd "y") #'ignore)
+        (vui-render (vui-region :keymap container-km
+                      (vui-button "B" :keymap button-km :on-click #'ignore)))
+        ;; Inside the rendered [B]
+        (let ((map (get-char-property 2 'keymap)))
+          ;; Button's own binding wins
+          (expect (lookup-key map (kbd "y")) :to-be 'ignore)
+          ;; Container bindings reachable for keys the button leaves unbound
+          (expect (lookup-key map (kbd "x")) :to-be 'forward-char)))))
+
+  (it "keeps default widget keys on buttons without a custom keymap"
+    (with-temp-buffer
+      (let ((container-km (make-sparse-keymap)))
+        (define-key container-km (kbd "RET") #'ignore)
+        (vui-render (vui-region :keymap container-km
+                      (vui-button "B" :on-click #'ignore)))
+        ;; RET on the button must still activate it, not run the
+        ;; container binding
+        (let ((map (get-char-property 2 'keymap)))
+          (expect (lookup-key map (kbd "RET"))
+                  :to-be 'widget-button-press))))))
+
 (describe "vui-list"
   (it "renders items vertically by default"
     (with-temp-buffer

--- a/vui.el
+++ b/vui.el
@@ -546,6 +546,14 @@ parsing and validation, use `vui-typed-field' from vui-components.el."
   rows        ; List of rows, each row is list of cell content (strings or vnodes)
   border)     ; nil, :ascii, :unicode
 
+;; Styling wrapper: face/keymap over the children's extent
+(cl-defstruct (vui-vnode-region (:include vui-vnode)
+                                (:constructor vui-vnode-region--create))
+  "Virtual node that applies face and keymap to its children's extent."
+  children   ; List of child vnodes
+  face       ; Face applied beneath the children's own faces
+  keymap)    ; Keymap cascading beneath the children's own keymaps
+
 ;; Component reference in vtree
 (cl-defstruct (vui-vnode-component (:include vui-vnode)
                                    (:constructor vui-vnode-component--create))
@@ -1076,6 +1084,45 @@ Example:
      :columns columns
      :rows rows
      :border border
+     :key key)))
+
+(defun vui-region (&rest args)
+  "Apply container-level styling to children.
+ARGS can start with keyword options, followed by children.
+
+Options:
+  :face FACE   - applied to the children's whole extent, beneath any
+                 faces the children set themselves, so child faces
+                 win.  Whitespace inserted by nested layout
+                 containers (separators, padding, indentation) is
+                 covered too.
+  :keymap MAP  - active over the children's extent.  Bindings
+                 cascade: a nested region's or a button's own keymap
+                 wins for keys it defines, unbound keys fall through
+                 to MAP, and keys unbound in MAP fall through to the
+                 buffer's usual keymaps.  Input fields keep their own
+                 keymap.
+  :key KEY     - for reconciliation
+
+Usage:
+  (vui-region :face \\='highlight :keymap my-map
+    (vui-hstack child1 child2))"
+  (let ((face nil)
+        (keymap nil)
+        (key nil)
+        (children nil))
+    ;; Parse keyword arguments
+    (while (and args (keywordp (car args)))
+      (pcase (pop args)
+        (:face (setq face (pop args)))
+        (:keymap (setq keymap (pop args)))
+        (:key (setq key (pop args)))))
+    ;; Remaining args are children
+    (setq children (remq nil (flatten-list args)))
+    (vui-vnode-region--create
+     :children children
+     :face face
+     :keymap keymap
      :key key)))
 
 (cl-defun vui-error-boundary (&key fallback on-error id children)
@@ -2357,6 +2404,45 @@ like hl-line."
               (overlay-get ov 'vui-placeholder))
       (delete-overlay ov))))
 
+(defun vui--apply-region-props (start end face keymap)
+  "Apply container-level FACE and KEYMAP to the region START..END.
+
+FACE is added with the lowest priority, so faces set by children win;
+whitespace inserted by layout containers (separators, padding,
+indentation) is covered as well.
+
+KEYMAP cascades beneath the children's own keymaps: plain text that
+already carries a keymap (from a nested styled region) gets a
+composed keymap where the existing map wins and unbound keys fall
+through to KEYMAP.  Buttons compose KEYMAP beneath their own keymap
+on their overlay (`widget-keymap' for buttons without a custom one),
+so button keys keep working.  Input fields are untouched: their
+overlay keymap shadows text properties."
+  (when (< start end)
+    (when face
+      (add-face-text-property start end face t))
+    (when keymap
+      (let ((pos start))
+        (while (< pos end)
+          (let ((next (min (next-single-char-property-change pos 'button nil end)
+                           (or (next-property-change pos nil end) end))))
+            (if (get-char-property pos 'button)
+                ;; Button: compose on its overlay so its own keys win
+                (dolist (overlay (overlays-at pos))
+                  (when (overlay-get overlay 'button)
+                    (overlay-put overlay 'keymap
+                                 (make-composed-keymap
+                                  (or (overlay-get overlay 'keymap)
+                                      widget-keymap)
+                                  keymap))))
+              ;; Plain text: compose under any nested region's keymap
+              (let ((existing (get-text-property pos 'keymap)))
+                (put-text-property pos next 'keymap
+                                   (if existing
+                                       (make-composed-keymap existing keymap)
+                                     keymap))))
+            (setq pos next)))))))
+
 (defun vui--inline-p (instance)
   "Return non-nil if INSTANCE was mounted inline (owns a region)."
   (and (vui-instance-region-start instance) t))
@@ -3333,6 +3419,19 @@ Handles :truncate and overflow:
         ;; by `vui--setup-field-placeholders'
         (when placeholder
           (widget-put w :vui-placeholder placeholder)))))
+
+   ;; Styled region - render children, then apply face/keymap on top
+   ((vui-vnode-region-p vnode)
+    (let ((start (point))
+          (children (vui-vnode-region-children vnode))
+          (idx 0))
+      (dolist (child children)
+        (let ((vui--render-path (cons idx vui--render-path)))
+          (vui--render-vnode child))
+        (cl-incf idx))
+      (vui--apply-region-props start (point)
+                               (vui-vnode-region-face vnode)
+                               (vui-vnode-region-keymap vnode))))
 
    ;; Component - reconcile and render
    ((vui-vnode-component-p vnode)


### PR DESCRIPTION
There was no way to style or bind keys over a span of UI: faces
could only be set per child, so whitespace inserted by layout
containers (separators, padding, indentation) was unstylable, and
row-level keybindings required per-widget keymaps (#41).

vui-region wraps children and applies :face and :keymap to their
whole rendered extent. The face is layered beneath the children's
own faces via add-face-text-property, so child faces win while
container-inserted whitespace gets styled - enabling row highlights
and panel backgrounds. The keymap cascades innermost-first: nested
regions compose under existing text-property keymaps, buttons get
the map composed beneath their overlay keymap (widget-keymap for
default buttons, so RET/TAB keep working), unbound keys fall
through outward, and input fields are left to their own keymap.

First part of #41; container shorthands (:face/:keymap directly on
stacks and boxes) build on this machinery next.

