### PR TITLE
docs: add vui-flex section to layout guide and README

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,7 +24,7 @@ The API is stable and used in [[#built-with-vui][real-world projects]].
 - *Reactive State* — Automatic re-rendering when state changes
 - *Hooks* — vui-use-effect, vui-use-ref, vui-use-memo, vui-use-callback
 - *Context* — Share data across component trees without prop drilling
-- *Layout Primitives* — hstack, vstack, box, table, list
+- *Layout Primitives* — hstack, vstack, flex, box, table, list
 - *Inline Mounting* — Ephemeral forms inside existing buffers, without taking them over
 - *Error Boundaries* — Graceful error handling with fallback UI
 - *Developer Tools* — Component inspector, timing profiler, debug logging
@@ -206,13 +206,14 @@ See [[file:docs/examples/][docs/examples/]] for complete, runnable examples:
 
 ** Layout
 
-| Component    | Description                            |
-|--------------+----------------------------------------|
-| =vui-hstack= | Horizontal layout with spacing         |
-| =vui-vstack= | Vertical layout with spacing/indent    |
-| =vui-box=    | Fixed-width container with alignment   |
-| =vui-table=  | Table with headers, borders, alignment |
-| =vui-list=   | Dynamic list with key-based reconcile  |
+| Component    | Description                             |
+|--------------+-----------------------------------------|
+| =vui-hstack= | Horizontal layout with spacing          |
+| =vui-vstack= | Vertical layout with spacing/indent     |
+| =vui-flex=   | Row distributing width among children   |
+| =vui-box=    | Fixed-width container with alignment    |
+| =vui-table=  | Table with headers, borders, alignment  |
+| =vui-list=   | Dynamic list with key-based reconcile   |
 
 ** Higher-Level Components (vui-components.el)
 

--- a/docs/guide/04-layout.org
+++ b/docs/guide/04-layout.org
@@ -441,6 +441,65 @@ Lists properly inherit indent from parent containers, or you can set it directly
                           (plist-get product :id)))))
 #+end_src
 
+* Flexible Width - =vui-flex=
+
+Sometimes a child should fill whatever space is left rather than have a
+fixed width - a field stretching between a label and a button, a footer
+with content pushed to both edges. =vui-flex= renders a row with a known
+total width and distributes the leftover:
+
+#+begin_src elisp
+(vui-flex :width 'fill-column
+  (vui-text "Name:")
+  (vui-flex-item :grow 1
+    (lambda (width) (vui-field :size width :key 'name)))
+  (vui-button "Save"))
+#+end_src
+
+Children render at their natural width. A child wrapped in
+=vui-flex-item= takes a share of the leftover, proportional to its
+=:grow= weight. When the wrapped child is a *function*, it receives its
+allotted width - that is what lets a field's =:size= be computed instead
+of guessed. A plain vnode child is padded inside a box instead, which is
+enough for text and backgrounds:
+
+#+begin_src elisp
+;; Two growers splitting leftover 1:2
+(vui-flex :width 40
+  (vui-flex-item :grow 1 (vui-text "left"))
+  (vui-flex-item :grow 2 (vui-text "right")))
+#+end_src
+
+=:width= accepts a number, =fill-column= (the default), =window=, or a
+function resolved at render time. Inside an indented =vui-vstack=, the
+inherited indent is subtracted automatically - no more
+=(- fill-column 20)= arithmetic.
+
+When nothing grows, =:justify= places the leftover:
+
+#+begin_src elisp
+(vui-flex :width 'fill-column :justify :space-between
+  (vui-text "v1.2.0")
+  (vui-text "47 items"))
+;; v1.2.0                                 47 items
+#+end_src
+
+Rows are single-line by design. If the children's natural widths already
+exceed the total, everything renders at natural width and growers get
+zero - the row degrades instead of erroring.
+
+For live resizing, use a function =:width= and re-render from a
+=window-size-change-functions= hook:
+
+#+begin_src elisp
+(vui-flex :width (lambda () (- (window-width) 2)) ...)
+
+(add-hook 'window-size-change-functions
+          (lambda (_frame)
+            (when-let* ((instance (vui-get-instance "*my-app*")))
+              (vui-rerender instance))))
+#+end_src
+
 * Nesting Layouts
 
 Layouts can be nested for complex structures:
@@ -515,6 +574,7 @@ available through the =vui-region= wrapper:
 |--------------+------------------------+-------------------------------------------|
 | =vui-hstack= | Horizontal arrangement | =:spacing=, =:face=, =:keymap=            |
 | =vui-vstack= | Vertical arrangement   | =:spacing=, =:indent=, =:face=, =:keymap= |
+| =vui-flex=   | Width distribution     | =:width=, =:justify=, =vui-flex-item= =:grow= |
 | =vui-box=    | Fixed-width container  | =:width=, =:align=, =:padding-left/right= |
 | =vui-table=  | Tabular data           | =:columns=, =:rows=, =:border=            |
 | =vui-list=   | Dynamic list rendering | items, render-fn, key-fn, =:indent=, =:spacing= |


### PR DESCRIPTION
Covers the grow model (function children receiving their allotted
width vs padded vnode children), width sources, justify, indent
subtraction, the single-line assumption, overflow degradation, and
the resize-hook pattern.

