### PR TITLE
fix: ignore resolve/reject from superseded vui-use-async loads

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,10 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 * Unreleased
 
+** Fixed
+
+- =vui-use-async= no longer lets a superseded load clobber the current one. When the key changed, the killed process's sentinel (or a late async result) could write the old entry back over the new pending one, surfacing a stale error or stale data and re-triggering the load on the next render. Resolve/reject callbacks from superseded loads are now ignored.
+
 ** Added
 
 - =vui-flex= - horizontal layout that distributes a total width among children (#3). Children render at natural width; wrap one in =vui-flex-item= to give it a proportional share of the leftover (=:grow= weights). A function child receives its allotted width, which lets fields actually fill remaining space: =(vui-flex-item :grow 1 (lambda (w) (vui-field :size w)))=. =:width= accepts a number, =fill-column= (default), =window=, or a function resolved at render time; =:justify= (=:start= / =:center= / =:end= / =:space-between=) places leftover width when nothing grows. Flex rows subtract inherited vstack indentation from their available width, accept =:face= / =:keymap= like other containers, and degrade to natural widths when content overflows the total. Single-row by design; multi-line children are measured by their widest line.

--- a/test/vui-hooks-test.el
+++ b/test/vui-hooks-test.el
@@ -586,6 +586,42 @@
           (kill-buffer "*test-memo-up2*"))))))
 
 (describe "use-async"
+  (it "ignores resolve and reject from superseded loads"
+    (let ((vui-render-delay nil)
+          (loads nil)                   ; (KEY RESOLVE REJECT) per load
+          (rendered nil))
+      (vui-defcomponent async-supersede-test (k)
+        :render (progn
+                  (setq rendered (vui-use-async k
+                                   (lambda (resolve reject)
+                                     (push (list k resolve reject) loads))))
+                  (vui-text (format "%s" (plist-get rendered :status)))))
+      (let ((instance (vui-mount (vui-component 'async-supersede-test :k 'a)
+                                 "*test-async-supersede*")))
+        (unwind-protect
+            (progn
+              (expect (length loads) :to-equal 1)
+              ;; Key changes before the first load settles
+              (vui-update-props instance '(:k b))
+              (expect (length loads) :to-equal 2)
+              (expect (plist-get rendered :status) :to-be 'pending)
+              ;; The superseded load rejecting must not clobber the new
+              ;; entry, and must not start a churn of new loads
+              (funcall (nth 2 (assq 'a loads)) "boom")
+              (vui--rerender-instance instance)
+              (expect (length loads) :to-equal 2)
+              (expect (plist-get rendered :status) :to-be 'pending)
+              (expect (plist-get rendered :error) :to-be nil)
+              ;; A late resolve from the superseded load is ignored too
+              (funcall (nth 1 (assq 'a loads)) "stale-data")
+              (vui--rerender-instance instance)
+              (expect (plist-get rendered :status) :to-be 'pending)
+              ;; The current load still settles normally
+              (funcall (nth 1 (assq 'b loads)) "fresh")
+              (expect (plist-get rendered :status) :to-be 'ready)
+              (expect (plist-get rendered :data) :to-equal "fresh"))
+          (kill-buffer "*test-async-supersede*")))))
+
   (it "returns ready status when resolve called synchronously"
     (let ((result nil))
       (vui-defcomponent async-test-sync ()

--- a/vui.el
+++ b/vui.el
@@ -2200,24 +2200,28 @@ Returns a plist with :status, :data, and :error."
       (let* ((root vui--root-instance)
              (buffer (vui-instance-buffer instance))
              (new-entry (list :key key :status 'pending :data nil :error nil :process nil))
-             ;; Create resolve callback
+             ;; Create resolve callback.  Both callbacks ignore loads
+             ;; that have been superseded by a key change: the killed
+             ;; process's sentinel (or a late async result) would
+             ;; otherwise write the old entry back over the new pending
+             ;; one and re-trigger its load on the next render.
              (resolve (lambda (data)
-                        (when (buffer-live-p buffer)
+                        (when (and (buffer-live-p buffer)
+                                   (eq (gethash async-id cache) new-entry))
                           (plist-put new-entry :status 'ready)
                           (plist-put new-entry :data data)
                           (plist-put new-entry :process nil)
-                          (puthash async-id new-entry cache)
                           ;; Trigger re-render (queued automatically when
                           ;; a render is already in progress)
                           (when root
                             (vui--rerender-instance root)))))
              ;; Create reject callback
              (reject (lambda (error-msg)
-                       (when (buffer-live-p buffer)
+                       (when (and (buffer-live-p buffer)
+                                  (eq (gethash async-id cache) new-entry))
                          (plist-put new-entry :status 'error)
                          (plist-put new-entry :error error-msg)
                          (plist-put new-entry :process nil)
-                         (puthash async-id new-entry cache)
                          ;; Trigger re-render (queued automatically when
                          ;; a render is already in progress)
                          (when root


### PR DESCRIPTION
When a load's key changes, the previous process is killed and a new
pending entry replaces the old one in the cache. But the old load's
resolve/reject closures captured the old entry: the killed process's
sentinel (or a late async result) re-wrote that old entry into the
cache, clobbering the new pending entry with a stale error or stale
data. The next render then saw a mismatched key and started yet
another load - one stale callback caused load churn.

Guard both callbacks: they only apply when their entry is still the
current one for the async slot.

