### PR TITLE
feat: warn on undeclared state keys and duplicate reconciliation keys

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -18,6 +18,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- Development-time warnings for two silent footguns: =vui-set-state= with a key that no component in scope declares (typos used to silently create new state), and sibling vnodes sharing a reconciliation key (they silently reconcile to one instance and share state). Both warn under the =vui= warning type, so they can be suppressed via =warning-suppress-types=.
 - The component inspector (=vui-inspect=) and state viewer (=vui-inspect-state=) now cover instances mounted via =vui-mount-inline=: with no explicit instance they list the buffer's root and every inline instance, labelled with its region.
 - =vui-rerender-on-resize= - opt-in, buffer-local hook that re-renders a buffer's VUI instances (root and inline) when its window size changes, coalescing resize bursts through the normal deferred scheduling. Pairs with =vui-flex= widths that depend on the window. =vui-cancel-rerender-on-resize= undoes it.
 - =vui-typed-field= (and the typed shortcuts like =vui-integer-field=) accept =:placeholder=, passed through to the underlying field and shown while it is empty.

--- a/test/vui-component-test.el
+++ b/test/vui-component-test.el
@@ -363,6 +363,48 @@
           (kill-buffer "*test-update-props*"))))))
 
 (describe "reconciliation"
+  (it "warns when siblings share a reconciliation key"
+    (let ((warnings nil))
+      (cl-letf (((symbol-function 'display-warning)
+                 (lambda (type message &rest _)
+                   (when (eq type 'vui)
+                     (push message warnings)))))
+        (vui-defcomponent dup-key-child ()
+          :render (vui-text "c"))
+        (vui-defcomponent dup-key-parent ()
+          :render (vui-fragment
+                   (vui-component 'dup-key-child :key 'same)
+                   (vui-component 'dup-key-child :key 'same)))
+        (let ((instance (vui-mount (vui-component 'dup-key-parent)
+                                   "*test-dup-key*")))
+          (unwind-protect
+              (progn
+                ;; Duplicates reconcile to one instance on re-render
+                (vui--rerender-instance instance)
+                (expect warnings :not :to-equal nil)
+                (expect (car warnings) :to-match "same"))
+            (kill-buffer "*test-dup-key*"))))))
+
+  (it "does not warn for distinct keys"
+    (let ((warnings nil))
+      (cl-letf (((symbol-function 'display-warning)
+                 (lambda (type message &rest _)
+                   (when (eq type 'vui)
+                     (push message warnings)))))
+        (vui-defcomponent distinct-key-child ()
+          :render (vui-text "c"))
+        (vui-defcomponent distinct-key-parent ()
+          :render (vui-fragment
+                   (vui-component 'distinct-key-child :key 'a)
+                   (vui-component 'distinct-key-child :key 'b)))
+        (let ((instance (vui-mount (vui-component 'distinct-key-parent)
+                                   "*test-distinct-key*")))
+          (unwind-protect
+              (progn
+                (vui--rerender-instance instance)
+                (expect warnings :to-equal nil))
+            (kill-buffer "*test-distinct-key*"))))))
+
   (it "preserves child component state across parent re-render"
     ;; Define a child component with state
     (vui-defcomponent stateful-child ()

--- a/test/vui-state-test.el
+++ b/test/vui-state-test.el
@@ -245,6 +245,51 @@
           (kill-buffer "*test-flush-a*")
           (kill-buffer "*test-flush-b*"))))))
 
+(describe "state key warnings"
+  (it "warns when setting a state key no component declares"
+    (let ((vui-render-delay nil)
+          (warnings nil))
+      (cl-letf (((symbol-function 'display-warning)
+                 (lambda (type message &rest _)
+                   (when (eq type 'vui)
+                     (push message warnings)))))
+        (vui-defcomponent typo-state-test ()
+          :state ((count 0))
+          :render (vui-button "inc"
+                    ;; Typo: :cout instead of :count
+                    :on-click (lambda () (vui-set-state :cout (1+ count)))))
+        (vui-mount (vui-component 'typo-state-test) "*test-typo-state*")
+        (unwind-protect
+            (with-current-buffer "*test-typo-state*"
+              (vui-test--click-button-at (point-min))
+              (expect (length warnings) :to-equal 1)
+              (expect (car warnings) :to-match ":cout"))
+          (kill-buffer "*test-typo-state*")))))
+
+  (it "does not warn for declared keys, including inherited ones"
+    (let ((vui-render-delay nil)
+          (warnings nil))
+      (cl-letf (((symbol-function 'display-warning)
+                 (lambda (type message &rest _)
+                   (when (eq type 'vui)
+                     (push message warnings)))))
+        (vui-defcomponent owned-state-child ()
+          :render (vui-button "inc"
+                    ;; :count lives on the parent
+                    :on-click (lambda () (vui-set-state :count #'1+))))
+        (vui-defcomponent owned-state-parent ()
+          :state ((count 0))
+          :render (vui-component 'owned-state-child))
+        (let ((instance (vui-mount (vui-component 'owned-state-parent)
+                                   "*test-owned-state*")))
+          (unwind-protect
+              (with-current-buffer "*test-owned-state*"
+                (vui-test--click-button-at (point-min))
+                (expect (plist-get (vui-instance-state instance) :count)
+                        :to-equal 1)
+                (expect warnings :to-equal nil))
+            (kill-buffer "*test-owned-state*")))))))
+
 (describe "re-entrant rendering"
   (it "does not corrupt the buffer when on-update sets state with immediate rendering"
     ;; vui-render-delay nil means vui-set-state renders immediately.

--- a/vui.el
+++ b/vui.el
@@ -1562,6 +1562,15 @@ sort.  In-place mutation is invisible to change detection
          (new-value (if (functionp value)
                         (funcall value current-value)
                       value)))
+    ;; No component in the chain declares KEY: almost certainly a typo.
+    ;; The set still happens (on the current component), but silently
+    ;; creating state is how typos go unnoticed.
+    (unless (plist-member current-state key)
+      (display-warning
+       'vui
+       (format "vui-set-state: %s is not a state key of any component in scope; setting it on <%s>"
+               key (vui-component-def-name (vui-instance-def target)))
+       :warning))
     (vui--debug-log 'state-change "<%s> state %s = %S"
                     (vui-component-def-name (vui-instance-def target))
                     key new-value)
@@ -2848,6 +2857,19 @@ INSTANCE is the component instance."
       (vui--timing-record 'commit component-name))
     ;; Update children list for next reconciliation
     (let ((new-children (nreverse vui--new-children)))
+      ;; Two sibling vnodes with the same key reconcile to the same
+      ;; instance, silently sharing state - warn, it is always a bug
+      (unless vui--measuring-p
+        (let ((seen (make-hash-table :test 'eq)))
+          (dolist (child new-children)
+            (if (gethash child seen)
+                (display-warning
+                 'vui
+                 (format "Duplicate reconciliation key %S under <%s>; siblings share one component instance"
+                         (vui-vnode-key (vui-instance-vnode child))
+                         component-name)
+                 :warning)
+              (puthash child t seen)))))
       ;; Call on-unmount for children that were removed
       (dolist (old-child old-children)
         (unless (memq old-child new-children)


### PR DESCRIPTION
Two mistakes were silent:

- (vui-set-state :cout ...) with a typo'd key creates brand-new
  state on the current component and re-renders; nothing ever points
  at the typo.
- Two sibling vnodes with the same :key reconcile to the same
  instance, so the components silently share state and the last
  render wins.

Both now emit a warning under the vui warning type (suppressible
via warning-suppress-types). The duplicate check skips measure
passes and uses a hash, so keyed lists stay O(n).

