### PR TITLE
docs: document anonymous face specs for :face (#77)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -28,6 +28,10 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 - =vui-region= - styling wrapper that applies =:face= and =:keymap= to its children's whole extent (#41). The face is layered beneath the children's own faces, so child faces win while separators, padding, and indentation inserted by nested layout containers get styled too. The keymap cascades: nested regions' and buttons' own keymaps win for keys they define, unbound keys fall through to the region's map, and from there to the buffer's usual keymaps; buttons keep their default =RET= / =TAB= behavior and input fields are untouched.
 - *Inline mounting* (#8): =vui-mount-inline= renders a component into a managed region at point (or a given position) inside an existing buffer, without taking the buffer over - the major mode and surrounding content are untouched, and a buffer can host any number of inline instances. State updates rewrite only the instance's region; region mutations are kept out of the undo history. =vui-unmount= now also accepts an instance and removes an inline instance's region while running the full teardown lifecycle (which also runs on buffer kill, and when =vui-mount= takes over a buffer that hosts inline instances). =vui-inline-instance-at= returns the inline instance at a position. Intended for ephemeral, disposable forms in interactive documents.
 
+** Documentation
+
+- Documented that =:face= accepts anonymous face specs, not just face symbols: a plist like =(:inherit error :weight ultra-bold)= or =(:foreground "red")= can style text inline without a =defface= (#77). Calls out the two gotchas that made this confusing - colors must be strings (=:foreground "red"=, not =red=), and there is no bare-symbol shorthand (=(error :weight ...)= does not work; use =(:inherit error :weight ...)=). Covered in the Primitives guide, the layout container styling section, and the =vui-text= docstring.
+
 * v1.1.0 - 2026-06-12
 
 ** Added

--- a/docs/guide/03-primitives.org
+++ b/docs/guide/03-primitives.org
@@ -16,16 +16,58 @@ The most basic primitive. Displays text content.
 
 *** With Face (Styling)
 
+The =:face= property is passed straight through to the Emacs =face= text
+property, so it accepts anything Emacs accepts there. There are three forms.
+
+A *face symbol* names a face defined elsewhere (built-in, from a theme, or
+your own =defface=):
+
 #+begin_src elisp
 (vui-text "Error: Something went wrong" :face 'error)
 (vui-text "Success!" :face 'success)
 (vui-text "Dimmed text" :face 'shadow)
 #+end_src
 
-*** With Text Properties
+An *anonymous face spec* lets you style text inline, without a =defface=. It
+is a plist of face attributes. Use =:inherit= to derive from an existing face
+and override individual attributes:
 
 #+begin_src elisp
-(vui-text "Important" :face '(:weight bold :foreground "red"))
+;; inherit `error', but make it heavier
+(vui-text "Critical" :face '(:inherit error :weight ultra-bold))
+
+;; plain attributes, no inheritance
+(vui-text "Important" :face '(:foreground "red" :weight bold))
+#+end_src
+
+*** Face Gotchas
+
+Two non-obvious snags catch people (both surfaced from real use - see
+[[https://github.com/d12frosted/vui.el/issues/77][issue #77]]):
+
+- *Colors are strings.* Write =:foreground "red"=, not =:foreground red=. The
+  symbol form silently fails - the text just renders unstyled, with no error.
+
+- *No bare-symbol shorthand.* You cannot write =(error :weight ultra-bold)= to
+  mean "inherit =error= and override the weight." A face spec is a plist of
+  attributes, so the leading symbol is not recognized. Use =:inherit=
+  instead:
+
+  #+begin_src elisp
+  ;; does NOT work - silently ignored
+  (vui-text "text" :face '(error :weight ultra-bold))
+
+  ;; works - inherit explicitly
+  (vui-text "text" :face '(:inherit error :weight ultra-bold))
+  #+end_src
+
+*** With Text Properties
+
+Any property other than =:face= and =:key= is passed through as a plain text
+property:
+
+#+begin_src elisp
+(vui-text "Hover me" :help-echo "a tooltip")
 #+end_src
 
 *** With Key (for Reconciliation)

--- a/docs/guide/04-layout.org
+++ b/docs/guide/04-layout.org
@@ -531,6 +531,10 @@ to their whole rendered extent - including the whitespace the container
 itself inserts (separators, padding, indentation), which cannot be
 styled child-by-child.
 
+As with =vui-text=, =:face= accepts either a face symbol or an anonymous
+face spec such as =(:inherit highlight :weight bold)= - see [[file:03-primitives.org][Primitives]] for
+the forms and gotchas.
+
 The face is layered *beneath* the children's own faces, so children
 keep their styling while everything else gets the container face. This
 makes selected-row highlighting one prop:

--- a/vui.el
+++ b/vui.el
@@ -913,7 +913,14 @@ Example:
 
 (defun vui-text (content &rest props)
   "Create a text vnode with CONTENT and optional PROPS.
-PROPS is a plist accepting :face, :key, and other text properties."
+PROPS is a plist accepting :face, :key, and other text properties.
+
+:face is passed straight through to the `face' text property, so it
+accepts a face symbol (\\='error), or an anonymous face spec - a plist of
+attributes such as (:inherit error :weight ultra-bold) or (:foreground
+\"red\").  Note that colors must be strings (\"red\", not the symbol red),
+and there is no bare-symbol shorthand: write (:inherit error ...), not
+(error ...)."
   (declare (indent 1))
   (vui-vnode-text--create
    :content content


### PR DESCRIPTION
Documents that `:face` accepts anonymous face specs, not just face symbols — the undocumented behaviour that caused confusion on David's stream and prompted #77.

`:face` is passed straight through to the Emacs `face` text property, so it accepts a face symbol (`'error`) or an anonymous face spec — a plist of attributes such as `(:inherit error :weight ultra-bold)` or `(:foreground "red")` — letting you style text inline without a `defface`.

The docs now also call out the two gotchas that made this confusing:

- Colors must be strings: `:foreground "red"`, not `:foreground red` (the symbol form silently fails).
- There is no bare-symbol shorthand: `(error :weight ...)` does not work; use `(:inherit error :weight ...)`.

## Changes

- **`docs/guide/03-primitives.org`** — expanded the face section to cover the three forms (symbol, `:inherit` + attributes, plain attributes) and added a dedicated "Face Gotchas" subsection; fixed the mislabeled "With Text Properties" example.
- **`docs/guide/04-layout.org`** — noted container `:face` accepts the same forms, cross-linking to the primitives guide.
- **`vui.el`** — expanded the `vui-text` docstring with the face-spec forms and gotchas.
- **`CHANGELOG.org`** — added a Documentation entry under Unreleased.

Closes #77.