### PR TITLE
fix: time the pomodoro example from the wall clock, not tick counts

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -15,6 +15,7 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 ** Fixed
 
 - =vui-use-async= no longer lets a superseded load clobber the current one. When the key changed, the killed process's sentinel (or a late async result) could write the old entry back over the new pending one, surfacing a stale error or stale data and re-triggering the load on the next render. Resolve/reject callbacks from superseded loads are now ignored.
+- The Pomodoro example (=docs/examples/10-pomodoro.el=) now keeps time from the wall clock instead of counting timer ticks. =run-with-timer= fires late when Emacs is busy and drops missed repeats, so decrementing the remaining seconds once per tick drifted and silently lost time. It now stores a deadline and recomputes the remaining seconds on each tick, so the countdown stays accurate regardless of timer jitter; the timer only drives the refresh rate.
 
 ** Added
 

--- a/docs/examples/10-pomodoro.el
+++ b/docs/examples/10-pomodoro.el
@@ -2,9 +2,13 @@
 
 ;; This file demonstrates a Pomodoro timer, focusing on:
 ;; - A countdown driven by `run-with-timer' inside `vui-use-effect'
+;; - Timing from the wall clock (a stored deadline) rather than by counting
+;;   timer ticks: `run-with-timer' fires late when Emacs is busy and even
+;;   drops missed repeats, so decrementing once per tick loses time.  We keep
+;;   a deadline and recompute the remaining seconds, so the clock stays
+;;   accurate no matter how the timer behaves.
 ;; - Restoring component context in timer callbacks with
 ;;   `vui-with-async-context'
-;; - Functional `vui-set-state' updates to avoid stale-closure bugs
 ;; - Effect cleanup that cancels the timer on pause and unmount
 ;; - Deriving session transitions (work <-> break) from state changes
 
@@ -30,6 +34,12 @@
   "Format SECONDS as MM:SS."
   (format "%02d:%02d" (/ seconds 60) (% seconds 60)))
 
+(defun vui-example-pomodoro--remaining-until (deadline)
+  "Whole seconds left until DEADLINE, a `float-time' value, clamped at 0.
+Rounded up so a freshly started clock shows its full duration for a
+full second before ticking down."
+  (max 0 (ceiling (- deadline (float-time)))))
+
 ;;; Progress Bar Component
 ;; A simple text gauge showing how much of the session remains.
 
@@ -50,80 +60,102 @@
 (vui-defcomponent pomodoro-timer ()
   :state ((mode 'work)
           (remaining vui-example-pomodoro-work-seconds)
-          (running nil)
+          ;; Absolute end time (a `float-time') while the clock runs; nil
+          ;; when paused.  `remaining' is the source of truth for display and
+          ;; the transition; while running it is recomputed from `deadline'
+          ;; on every tick, so it tracks real elapsed time instead of a count
+          ;; of how many times the timer happened to fire.
+          (deadline nil)
           (completed 0))
 
   :render
-  (progn
-    ;; Tick: while running, decrement once per second.  The timer
-    ;; callback runs asynchronously, so wrap it in `vui-with-async-context'
-    ;; and use a functional update so it never captures a stale `remaining'.
-    ;; The effect re-runs whenever `running' changes; its cleanup cancels
-    ;; the timer when we pause or when the component unmounts.
-    (vui-use-effect (running)
-      (when running
-        (let ((timer (run-with-timer
-                      1 1
-                      (vui-with-async-context
-                       (vui-set-state :remaining
-                                      (lambda (n) (max 0 (1- n))))))))
-          (lambda () (cancel-timer timer)))))
+  ;; "Running" is simply "there is a deadline to count down to".
+  (let ((running (and deadline t)))
+    (progn
+      ;; Tick: while running, refresh `remaining' from the wall clock.  The
+      ;; timer only drives the refresh rate; the value comes from `deadline',
+      ;; so a late or dropped tick changes how smoothly the clock updates,
+      ;; not how much time it reports.  The callback runs asynchronously, so
+      ;; wrap it in `vui-with-async-context'.  The effect re-runs whenever
+      ;; `deadline' changes (start, pause, transition); its cleanup cancels
+      ;; the timer.
+      (vui-use-effect (deadline)
+        (when deadline
+          (let ((timer (run-with-timer
+                        1 1
+                        (vui-with-async-context
+                         (vui-set-state
+                          :remaining
+                          (vui-example-pomodoro--remaining-until deadline))))))
+            (lambda () (cancel-timer timer)))))
 
-    ;; Transition: when the countdown hits zero, switch sessions.  This is
-    ;; derived from `remaining', so it stays correct no matter what drove
-    ;; the countdown to zero.
-    (vui-use-effect (remaining)
-      (when (and running (zerop remaining))
-        (let ((next-mode (if (eq mode 'work) 'break 'work)))
-          (message "Pomodoro: %s session over -> starting %s"
-                   mode next-mode)
-          (when (fboundp 'ding) (ding))
-          (vui-batch
-           (vui-set-state :mode next-mode)
-           (vui-set-state :remaining (vui-example-pomodoro--duration next-mode))
-           (when (eq mode 'work)
-             (vui-set-state :completed #'1+))))))
+      ;; Transition: when the countdown hits zero, switch sessions.  This is
+      ;; derived from `remaining', so it stays correct no matter what drove
+      ;; the countdown to zero (a tick or the Skip button).
+      (vui-use-effect (remaining)
+        (when (and running (zerop remaining))
+          (let* ((next-mode (if (eq mode 'work) 'break 'work))
+                 (next-seconds (vui-example-pomodoro--duration next-mode)))
+            (message "Pomodoro: %s session over -> starting %s"
+                     mode next-mode)
+            (when (fboundp 'ding) (ding))
+            (vui-batch
+             (vui-set-state :mode next-mode)
+             (vui-set-state :remaining next-seconds)
+             (vui-set-state :deadline (+ (float-time) next-seconds))
+             (when (eq mode 'work)
+               (vui-set-state :completed #'1+))))))
 
-    (vui-vstack
-     ;; Header
-     (vui-text "Pomodoro Timer" :face 'outline-1)
-     (vui-newline)
+      (vui-vstack
+       ;; Header
+       (vui-text "Pomodoro Timer" :face 'outline-1)
+       (vui-newline)
 
-     ;; Current session label
-     (vui-text (if (eq mode 'work) "Work" "Break")
-       :face (if (eq mode 'work) 'success 'warning))
+       ;; Current session label
+       (vui-text (if (eq mode 'work) "Work" "Break")
+         :face (if (eq mode 'work) 'success 'warning))
 
-     ;; Big clock
-     (vui-text (vui-example-pomodoro--format remaining)
-       :face 'bold)
+       ;; Big clock
+       (vui-text (vui-example-pomodoro--format remaining)
+         :face 'bold)
 
-     ;; Progress gauge
-     (vui-component 'pomodoro-progress
-       :mode mode
-       :remaining remaining)
+       ;; Progress gauge
+       (vui-component 'pomodoro-progress
+         :mode mode
+         :remaining remaining)
 
-     ;; Controls
-     (vui-newline)
-     (vui-hstack
-      :spacing 2
-      (vui-button (if running "Pause" "Start")
-        :on-click (lambda () (vui-set-state :running (not running))))
-      (vui-button "Reset"
-        :on-click (lambda ()
-                    (vui-batch
-                     (vui-set-state :running nil)
-                     (vui-set-state :remaining
-                                    (vui-example-pomodoro--duration mode)))))
-      (vui-button "Skip"
-        :face 'font-lock-comment-face
-        :on-click (lambda ()
-                    ;; Jump to the end; the transition effect handles the rest.
-                    (vui-set-state :remaining 0))))
+       ;; Controls
+       (vui-newline)
+       (vui-hstack
+        :spacing 2
+        (vui-button (if running "Pause" "Start")
+          :on-click
+          (lambda ()
+            (if running
+                ;; Pause: freeze the time left, then stop the clock.
+                (vui-batch
+                 (vui-set-state :remaining
+                                (vui-example-pomodoro--remaining-until deadline))
+                 (vui-set-state :deadline nil))
+              ;; Start/resume: anchor a deadline `remaining' seconds out.
+              (vui-set-state :deadline (+ (float-time) remaining)))))
+        (vui-button "Reset"
+          :on-click
+          (lambda ()
+            (vui-batch
+             (vui-set-state :deadline nil)
+             (vui-set-state :remaining
+                            (vui-example-pomodoro--duration mode)))))
+        (vui-button "Skip"
+          :face 'font-lock-comment-face
+          :on-click (lambda ()
+                      ;; Jump to the end; the transition effect handles the rest.
+                      (vui-set-state :remaining 0))))
 
-     ;; Stats
-     (vui-newline)
-     (vui-text (format "Completed pomodoros: %d" completed)
-       :face 'font-lock-comment-face))))
+       ;; Stats
+       (vui-newline)
+       (vui-text (format "Completed pomodoros: %d" completed)
+         :face 'font-lock-comment-face)))))
 
 ;;; Demo Function
 


### PR DESCRIPTION
The Pomodoro example (`docs/examples/10-pomodoro.el`) measured time by counting timer ticks - it decremented the remaining seconds once per `run-with-timer` tick. That is not the same as measuring elapsed time: `run-with-timer` fires late when Emacs is busy (long commands, GC) and `timer-event-handler` drops missed repeats rather than firing a catch-up burst, so over a session the clock drifts and silently loses time, and never recovers it.

This switches the example to time from the wall clock:

- Store a `deadline` (a `float-time`) when the clock starts.
- On each tick, recompute the remaining seconds from `deadline` instead of subtracting one. The timer now only drives the refresh rate; the displayed value comes from the wall clock, so a late or dropped tick changes how smoothly the clock updates, not how much time it reports.
- Pause freezes the computed remaining and clears `deadline`; resume anchors a fresh deadline. `running` is derived from whether a deadline is set, keeping a single source of truth.
- `remaining` stays the source of truth for the display and the work/break transition, so the progress gauge and the `remaining`-keyed transition effect are unchanged.

Byte-compiles clean with warnings-as-errors. Surfaced while writing a pomodoro walkthrough blog post; thanks to the drift question that prompted it.