### PR TITLE
test: add render performance benchmark suite

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,10 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 * Unreleased
 
+** Internal
+
+- Added a benchmark suite (=benchmarks/vui-bench.el=, run with =eldev emacs --batch -l benchmarks/vui-bench.el -f vui-bench-run=) that characterizes render performance: scaling with content, cost of a small update in a large UI, streaming append into a growing buffer, raw render throughput, and widget-heavy re-renders. Not part of =eldev test= (#83).
+
 ** Documentation
 
 - Added a runnable =vui-flex= example (=docs/examples/12-flex-layout.el=): a form whose fields stretch to fill the window, the four =:justify= modes, and proportional =:grow= panels.

--- a/benchmarks/README.org
+++ b/benchmarks/README.org
@@ -1,0 +1,51 @@
+#+TITLE: vui.el benchmarks
+
+A characterization suite for vui's render performance. The point is not
+micro-numbers but finding where vui starts to hurt.
+
+* Running
+
+#+begin_src sh
+eldev emacs --batch -l benchmarks/vui-bench.el -f vui-bench-run
+#+end_src
+
+Or load =benchmarks/vui-bench.el= and =M-x vui-bench-run=. The report
+goes to stdout (batch) or the echo area / =*Messages*= (interactive).
+
+These are not part of =eldev test= - they are slow and noisy, and not
+meant to gate CI.
+
+* Scenarios
+
+| Scenario          | What it measures                                            |
+|-------------------+------------------------------------------------------------|
+| Initial render    | Mount cost vs item count                                   |
+| Re-render         | Full re-render cost vs item count (tree unchanged)         |
+| Single-item update | Cost of changing one item in a list of N                  |
+| Streaming append  | Per-line re-render as a transcript grows                   |
+| Update throughput | Raw re-render floor for a trivial UI                       |
+| Widgets           | Full re-render cost vs interactive widget (button) count   |
+
+* What to expect (the shape, not the numbers)
+
+vui re-renders by rebuilding the buffer (or an inline region) from the
+component tree each cycle, so the durable findings are about scaling
+shape, not absolute milliseconds (which depend on the machine):
+
+- *Plain text/content scales linearly* and is cheap - thousands of rows
+  render in single-digit milliseconds.
+- *A small change costs a full re-render.* Updating one item in a list
+  of N costs about the same as re-rendering all N - there is no partial
+  patching yet (see issue #82).
+- *Streaming append is the sharp case.* Appending one line and
+  re-rendering is O(current length), so streaming M lines into a growing
+  transcript is O(M^2) overall. This is the case where a marker-based
+  append (insert at the end, no full rebuild) wins, and the main
+  motivation for incremental rendering (#82).
+- *Widgets are the steepest cliff.* Interactive widgets (buttons,
+  fields) are markedly more expensive than text and scale worse than
+  linearly, because each one is created through =widget.el= on every
+  render. Widget-heavy re-renders are where vui slows down first.
+
+Re-run after performance changes and compare; the suite exists so those
+changes can be justified and regressions caught.

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -1,0 +1,197 @@
+;;; vui-bench.el --- Performance benchmarks for vui.el -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; A characterization suite for vui.el's render performance. The goal is
+;; not micro-numbers but finding where vui starts to hurt: how cost
+;; scales with content, what a small update in a large UI costs, how a
+;; streaming append into a growing buffer behaves, and how widget-heavy
+;; UIs compare to plain text.
+;;
+;; These are not run by `eldev test' (they are slow and noisy). Run them
+;; explicitly:
+;;
+;;   eldev emacs --batch -l benchmarks/vui-bench.el -f vui-bench-run
+;;
+;; or interactively: load this file and M-x vui-bench-run.
+
+;;; Code:
+
+(require 'vui)
+(require 'benchmark)
+(require 'cl-lib)
+
+;;; Harness
+
+(defun vui-bench--ms (seconds)
+  "Format SECONDS as milliseconds."
+  (format "%.3f" (* 1000 seconds)))
+
+(defun vui-bench--header (title)
+  "Print a section TITLE."
+  (message "")
+  (message "=== %s ===" title))
+
+(defun vui-bench--row (&rest cells)
+  "Print a table row from CELLS (each a cons of (WIDTH . STRING))."
+  (message "%s"
+           (mapconcat (lambda (c)
+                        (let ((w (car c)) (s (format "%s" (cdr c))))
+                          (concat s (make-string (max 0 (- w (length s))) ?\s))))
+                      cells "  ")))
+
+(defmacro vui-bench--elapse (&rest body)
+  "Run BODY once after a GC, return elapsed seconds."
+  `(progn (garbage-collect) (car (benchmark-run 1 ,@body))))
+
+;;; Components used by the scenarios
+
+(vui-defcomponent vui-bench-text-list (n)
+  :render (vui-list (number-sequence 1 (or n 0))
+                    (lambda (i)
+                      (vui-text (format "row %d - representative line of content here" i)))
+                    #'identity))
+
+(vui-defcomponent vui-bench-item-list (n)
+  :state ((items (cl-loop for i from 1 to (or n 0)
+                          collect (list :id i :label (format "row %d - content" i)))))
+  :render (vui-list items
+                    (lambda (it) (vui-text (plist-get it :label)))
+                    (lambda (it) (plist-get it :id))))
+
+(vui-defcomponent vui-bench-button-list (n)
+  :render (vui-list (number-sequence 1 (or n 0))
+                    (lambda (i) (vui-button (format "btn %d" i) :on-click #'ignore))
+                    #'identity))
+
+(vui-defcomponent vui-bench-transcript ()
+  :state ((lines nil))
+  :render (vui-list (reverse lines) (lambda (l) (vui-text l)) #'identity))
+
+(vui-defcomponent vui-bench-counter ()
+  :state ((n 0))
+  :render (vui-text (format "count: %d" n)))
+
+;;; Scenarios
+
+(defconst vui-bench--sizes '(50 200 500 1000 2000 4000)
+  "Item counts swept by the scaling scenarios.")
+
+(defun vui-bench-initial-render ()
+  "Initial mount cost vs item count."
+  (vui-bench--header "Initial render (mount N text rows)")
+  (vui-bench--row '(10 . "N") '(14 . "total/mount"))
+  (dolist (n vui-bench--sizes)
+    (let* ((buf (format "*vui-bench-init-%d*" n))
+           (el (/ (vui-bench--elapse
+                   (dotimes (_ 3) (vui-mount (vui-component 'vui-bench-text-list :n n) buf)))
+                  3.0)))
+      (vui-unmount buf)
+      (when (get-buffer buf) (kill-buffer buf))
+      (vui-bench--row (cons 10 n) (cons 14 (concat (vui-bench--ms el) " ms"))))))
+
+(defun vui-bench-rerender ()
+  "Full re-render cost vs item count (tree unchanged)."
+  (vui-bench--header "Re-render (full re-render of N text rows)")
+  (vui-bench--row '(10 . "N") '(14 . "per re-render"))
+  (dolist (n vui-bench--sizes)
+    (let* ((buf (format "*vui-bench-rr-%d*" n))
+           (inst (vui-mount (vui-component 'vui-bench-text-list :n n) buf))
+           (el (/ (vui-bench--elapse (dotimes (_ 5) (vui--rerender-instance inst))) 5.0)))
+      (vui-unmount inst)
+      (when (get-buffer buf) (kill-buffer buf))
+      (vui-bench--row (cons 10 n) (cons 14 (concat (vui-bench--ms el) " ms"))))))
+
+(defun vui-bench-single-update ()
+  "Cost of changing ONE item in a list of N, then re-rendering."
+  (vui-bench--header "Single-item update in a list of N")
+  (vui-bench--row '(10 . "N") '(14 . "per update"))
+  (dolist (n vui-bench--sizes)
+    (let* ((buf (format "*vui-bench-su-%d*" n))
+           (inst (vui-mount (vui-component 'vui-bench-item-list :n n) buf))
+           (toggle 0)
+           (el (/ (vui-bench--elapse
+                   (dotimes (_ 5)
+                     (let ((vui--current-instance inst))
+                       (setq toggle (1+ toggle))
+                       ;; replace one item with a fresh label, then render
+                       (vui-set-state
+                        :items
+                        (lambda (items)
+                          (let ((copy (copy-sequence items)))
+                            (setcar copy (list :id 1 :label (format "row 1 - %d" toggle)))
+                            copy))))))
+                  5.0)))
+      (vui-unmount inst)
+      (when (get-buffer buf) (kill-buffer buf))
+      (vui-bench--row (cons 10 n) (cons 14 (concat (vui-bench--ms el) " ms"))))))
+
+(defun vui-bench-streaming ()
+  "Append lines into a growing transcript, one render per line."
+  (vui-bench--header "Streaming append (per-line re-render as transcript grows)")
+  (vui-bench--row '(10 . "at line") '(14 . "this append") '(14 . "cumulative"))
+  (let* ((buf "*vui-bench-stream*")
+         (inst (vui-mount (vui-component 'vui-bench-transcript) buf))
+         (line "2026-06-24 12:00:00  log line with a bit of representative content")
+         (samples '(100 500 1000 2000))
+         (total 0.0))
+    (dotimes (i 2000)
+      (let ((el (vui-bench--elapse
+                 (let ((vui--current-instance inst))
+                   (vui-set-state :lines (lambda (old) (cons line old)))))))
+        (setq total (+ total el))
+        (when (memq (1+ i) samples)
+          (vui-bench--row (cons 10 (1+ i))
+                          (cons 14 (concat (vui-bench--ms el) " ms"))
+                          (cons 14 (concat (vui-bench--ms total) " ms"))))))
+    (vui-unmount inst)
+    (when (get-buffer buf) (kill-buffer buf))))
+
+(defun vui-bench-throughput ()
+  "Raw re-render throughput for a trivial UI (lower bound per render)."
+  (vui-bench--header "Update throughput (trivial counter, 2000 updates)")
+  (let* ((buf "*vui-bench-tp*")
+         (inst (vui-mount (vui-component 'vui-bench-counter) buf))
+         (el (vui-bench--elapse
+              (let ((vui--current-instance inst))
+                (dotimes (_ 2000) (vui-set-state :n #'1+))))))
+    (vui-unmount inst)
+    (when (get-buffer buf) (kill-buffer buf))
+    (vui-bench--row '(16 . "2000 updates") (cons 14 (concat (vui-bench--ms el) " ms total")))
+    (vui-bench--row '(16 . "per update") (cons 14 (concat (vui-bench--ms (/ el 2000.0)) " ms")))))
+
+(defun vui-bench-widgets ()
+  "Re-render cost vs interactive widget count (buttons)."
+  (vui-bench--header "Widgets (full re-render of N buttons)")
+  (vui-bench--row '(10 . "N") '(14 . "per re-render"))
+  (dolist (n '(50 200 500 1000))
+    (let* ((buf (format "*vui-bench-w-%d*" n))
+           (inst (vui-mount (vui-component 'vui-bench-button-list :n n) buf))
+           (el (/ (vui-bench--elapse (dotimes (_ 5) (vui--rerender-instance inst))) 5.0)))
+      (vui-unmount inst)
+      (when (get-buffer buf) (kill-buffer buf))
+      (vui-bench--row (cons 10 n) (cons 14 (concat (vui-bench--ms el) " ms"))))))
+
+;;;###autoload
+(defun vui-bench-run ()
+  "Run the full vui benchmark suite and print a report."
+  (interactive)
+  (let ((vui-render-delay nil)
+        (vui-timing-enabled nil)
+        (vui-debug-enabled nil))
+    (message "VUI benchmark suite (Emacs %s)" emacs-version)
+    (vui-bench-initial-render)
+    (vui-bench-rerender)
+    (vui-bench-single-update)
+    (vui-bench-streaming)
+    (vui-bench-throughput)
+    (vui-bench-widgets)
+    (message "")
+    (message "done.")))
+
+(provide 'vui-bench)
+;;; vui-bench.el ends here


### PR DESCRIPTION
Closes #83.

Adds benchmarks/vui-bench.el - a characterization suite aimed at finding where vui's full-re-render model starts to hurt, not just micro-numbers. Run with:

```
eldev emacs --batch -l benchmarks/vui-bench.el -f vui-bench-run
```

Not part of eldev test (slow/noisy); compiles clean under warnings-as-errors. benchmarks/README.org covers how to run and the durable findings.

## Results (Emacs 31, one machine - shape matters more than absolute ms)

Initial render (mount N text rows): linear, ~1.9us/row (4000 rows = 7.6ms).
Re-render N text rows: linear, ~1.4us/row (4000 = 5.7ms).
Single-item update in a list of N: same cost as a full re-render (1000 = 1.2ms, 4000 = 4.7ms) - a one-item change pays for the whole tree.

Streaming append (per-line re-render as transcript grows):
- at 100 lines: 0.13ms/append, 9ms cumulative
- at 500: 0.60ms, 164ms
- at 1000: 1.13ms, 631ms
- at 2000: 2.30ms, 2394ms

Per-append is O(length), so streaming M lines is O(M^2) - ~2.4s to stream 2000 lines.

Update throughput (trivial counter): 0.005ms/update. Render overhead floor is negligible.

Widgets (full re-render of N buttons): 50 = 0.65ms, 200 = 4.5ms, 500 = 18.8ms, 1000 = 79.9ms. Super-linear - widget-heavy re-renders are the steepest cliff.

## Where vui breaks

- Plain text/content: fine into thousands of rows.
- Small change in a big UI: costs a full re-render (motivates #82).
- Streaming into a growing buffer: O(M^2), the case a marker-based append wins (motivates #82, matches the pi.el discussion).
- Widgets: the sharpest cliff - ~80ms/render at 1000 buttons, scales worse than linearly because each widget goes through widget.el every render.
