### PR TITLE
perf: reconcile child lookup in O(n) instead of O(n^2)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -36,6 +36,16 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   is O(1) regardless of buffer size. It only ever skips provably-unchanged
   work (a single =eq= check, no bookkeeping), so it carries no risk and
   needs no opt-in.
+- Reconciling a list of children is now O(n) instead of O(n^2).
+  =vui--find-matching-child= used to linear-scan the existing children for
+  every child on every render, so a flat list of S components cost O(S^2)
+  to reconcile (and streaming N of them O(N^3)). It now builds a per-render
+  lookup once - a hash keyed by =(type . key)= for keyed children, a vector
+  for positional reuse - so each match is O(1). Reuse semantics are
+  unchanged (keyed children by key, unkeyed by position, first match wins).
+  Measured in batch: one re-render of a 2000-item keyed list drops from
+  ~1660ms to ~51ms (32x), and the gap widens with size since this is an
+  asymptotic change, not a constant factor.
 
 ** Internal
 

--- a/test/vui-reconcile-test.el
+++ b/test/vui-reconcile-test.el
@@ -1,0 +1,103 @@
+;;; vui-reconcile-test.el --- Child reconciliation lookup invariants -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Characterization tests for child reconciliation: which existing child
+;; instance gets reused for each new child vnode.  These pin the exact
+;; reuse semantics so the O(1)-lookup rewrite of `vui--find-matching-child'
+;; (replacing the per-child linear scan that made a flat list of S
+;; children O(S^2) to reconcile) is provably behavior-preserving.
+;;
+;; The two rules being locked:
+;;   - keyed children are reused by (type, key), regardless of position
+;;     (so state follows the key across reorders and mid-list inserts);
+;;   - unkeyed children are reused by position (type at the same index).
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+(require 'cl-lib)
+
+(vui-defcomponent vui-rc-cell (id)
+  "A trivial keyed/unkeyed list cell."
+  :render (vui-text (format "%s" id)))
+
+(vui-defcomponent vui-rc-parent (ids keyed)
+  "Render IDS as `vui-rc-cell' children, keyed by id when KEYED."
+  :render
+  (apply #'vui-vstack
+         (mapcar (lambda (i)
+                   (if keyed
+                       (vui-component 'vui-rc-cell :key i :id i)
+                     (vui-component 'vui-rc-cell :id i)))
+                 ids)))
+
+(defun vui-rc--by-id (root)
+  "Map each `vui-rc-cell' :id under ROOT to its instance object."
+  (let ((h (make-hash-table :test 'eql)))
+    (dolist (i (vui-get-component-instances 'vui-rc-cell root))
+      (puthash (plist-get (vui-instance-props i) :id) i h))
+    h))
+
+(defun vui-rc--kill (buf)
+  (when (get-buffer buf)
+    (with-current-buffer buf
+      (let ((inhibit-modification-hooks t)) (kill-buffer buf)))))
+
+(describe "reconcile: keyed children are reused by key"
+  (it "keeps each key's exact instance across a full reverse (N=50)"
+    (let* ((vui-render-delay nil)
+           (n 50)
+           (ids (number-sequence 1 n))
+           (buf "*vui-rc-keyed*")
+           (inst (vui-mount (vui-component 'vui-rc-parent :ids ids :keyed t) buf)))
+      (unwind-protect
+          (let ((before (vui-rc--by-id inst)))
+            (vui-update inst (list :ids (reverse ids) :keyed t))
+            (let ((after (vui-rc--by-id inst)))
+              (expect (hash-table-count after) :to-equal n)
+              (dolist (id ids)
+                ;; same instance object reused for this key, not recreated
+                (expect (gethash id after) :to-be (gethash id before)))))
+        (vui-rc--kill buf))))
+
+  (it "preserves existing instances when inserting at the front"
+    (let* ((vui-render-delay nil)
+           (ids (number-sequence 1 20))
+           (buf "*vui-rc-insert*")
+           (inst (vui-mount (vui-component 'vui-rc-parent :ids ids :keyed t) buf)))
+      (unwind-protect
+          (let ((before (vui-rc--by-id inst)))
+            (vui-update inst (list :ids (cons 0 ids) :keyed t))
+            (let ((after (vui-rc--by-id inst)))
+              (dolist (id ids)
+                (expect (gethash id after) :to-be (gethash id before)))
+              ;; the inserted key gets a fresh instance
+              (expect (gethash 0 after) :not :to-be nil)
+              (expect (gethash 0 before) :to-be nil)))
+        (vui-rc--kill buf)))))
+
+(describe "reconcile: unkeyed children are reused by position"
+  (it "reuses the same N instances when ids change but count is stable"
+    (let* ((vui-render-delay nil)
+           (n 40)
+           (ids (number-sequence 1 n))
+           (buf "*vui-rc-pos*")
+           (inst (vui-mount (vui-component 'vui-rc-parent :ids ids :keyed nil) buf)))
+      (unwind-protect
+          (let ((before (vui-get-component-instances 'vui-rc-cell inst)))
+            (expect (length before) :to-equal n)
+            ;; change every id; unkeyed => reuse by position, no recreation
+            (vui-update inst (list :ids (mapcar (lambda (i) (+ 100 i)) ids)
+                                   :keyed nil))
+            (let ((after (vui-get-component-instances 'vui-rc-cell inst)))
+              (expect (length after) :to-equal n)
+              (dolist (a after)
+                (expect (memq a before) :not :to-be nil))))
+        (vui-rc--kill buf)))))
+
+(provide 'vui-reconcile-test)
+;;; vui-reconcile-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -738,6 +738,14 @@ may bail out of re-rendering (its consumed context values are unchanged).")
 (defvar vui--new-children nil
   "Accumulator for child instances created during render.")
 
+(defvar vui--reconcile-lookup nil
+  "O(1) lookup over the current parent's existing children during render.
+Bound per instance by `vui--render-instance' to the result of
+`vui--build-reconcile-lookup', and consulted by `vui--find-matching-child'
+so reconciling a list of S children is O(S) rather than O(S^2).  Nil when
+no lookup was built (e.g. measurement passes), in which case
+`vui--find-matching-child' falls back to a linear scan.")
+
 (defvar vui--render-path nil
   "Current vnode path during rendering.
 A list of indices from root to current position, e.g., (0 1 2) means
@@ -2907,6 +2915,10 @@ the root re-render commit incrementally (see `vui--commit-root')."
          (vui--memo-index 0)      ; Reset memo counter for this component
          (vui--async-index 0)     ; Reset async counter for this component
          (old-children (vui-instance-children instance))
+         ;; O(1) child lookup for this render, so reconciling S children is
+         ;; O(S) not O(S^2).  Nil when there is nothing to reuse.
+         (vui--reconcile-lookup (and old-children
+                                     (vui--build-reconcile-lookup instance old-children)))
          (def (vui-instance-def instance))
          (component-name (vui-component-def-name def))
          (render-fn (vui-component-def-render-fn def))
@@ -3061,22 +3073,51 @@ requests for this tree become no-ops."
   (vui--cancel-render-timer instance)
   (vui--detach-instance instance))
 
+(defun vui--build-reconcile-lookup (parent children)
+  "Build an O(1) reconciliation lookup over PARENT's existing CHILDREN.
+Returns a plist with :parent (for validation), :vec (a vector of the
+children for positional/index reuse) and :by-key (a hash from (TYPE . KEY)
+to the FIRST child with that type and key, matching the first-match
+semantics of the previous linear `cl-find-if').  Built once per parent
+render, so per-child lookup in `vui--find-matching-child' is O(1)."
+  (let ((by-key (make-hash-table :test 'equal)))
+    (dolist (child children)
+      (let ((key (vui-vnode-key (vui-instance-vnode child))))
+        (when key
+          (let ((hk (cons (vui-component-def-name (vui-instance-def child)) key)))
+            ;; first wins: keep the earliest child for a (type . key)
+            (unless (gethash hk by-key)
+              (puthash hk child by-key))))))
+    (list :parent parent :vec (vconcat children) :by-key by-key)))
+
 (defun vui--find-matching-child (parent type key index)
-  "Find a child of PARENT matching TYPE and KEY or INDEX."
+  "Find a child of PARENT matching TYPE and KEY or INDEX.
+Uses `vui--reconcile-lookup' for O(1) matching when it was built for
+PARENT; otherwise falls back to a linear scan (identical semantics)."
   (when parent
-    (let ((children (vui-instance-children parent)))
-      (if key
-          ;; Key-based lookup - find child with same type AND key
-          (cl-find-if (lambda (child)
-                        (and (eq (vui-component-def-name (vui-instance-def child)) type)
-                             (equal (vui-vnode-key (vui-instance-vnode child)) key)))
-                      children)
-        ;; Index-based lookup - find child at same global position with same type
-        ;; This matches React's behavior for children without keys
-        (let ((child-at-index (nth index children)))
-          (when (and child-at-index
-                     (eq (vui-component-def-name (vui-instance-def child-at-index)) type))
-            child-at-index))))))
+    (if (and vui--reconcile-lookup
+             (eq (plist-get vui--reconcile-lookup :parent) parent))
+        ;; Fast path: O(1) lookup built for this render.
+        (if key
+            ;; Key-based: child with same type AND key (first match).
+            (gethash (cons type key) (plist-get vui--reconcile-lookup :by-key))
+          ;; Index-based: child at same global position with same type.
+          (let* ((vec (plist-get vui--reconcile-lookup :vec))
+                 (child (and (< index (length vec)) (aref vec index))))
+            (when (and child
+                       (eq (vui-component-def-name (vui-instance-def child)) type))
+              child)))
+      ;; Fallback: linear scan (e.g. no lookup built during measurement).
+      (let ((children (vui-instance-children parent)))
+        (if key
+            (cl-find-if (lambda (child)
+                          (and (eq (vui-component-def-name (vui-instance-def child)) type)
+                               (equal (vui-vnode-key (vui-instance-vnode child)) key)))
+                        children)
+          (let ((child-at-index (nth index children)))
+            (when (and child-at-index
+                       (eq (vui-component-def-name (vui-instance-def child-at-index)) type))
+              child-at-index)))))))
 
 (defun vui--create-instance (vnode &optional parent)
   "Create a new component instance from VNODE with optional PARENT."


### PR DESCRIPTION
While benchmarking the streaming/agent-UI case (groundwork for the `vui-stream` work, #82), I found that re-rendering a list is way more expensive than it should be: a flat list of S children reconciles in **O(S^2)**, and streaming N of them is O(N^3).

The culprit is `vui--find-matching-child`: for every child on every render it linear-scans the whole existing child list (`cl-find-if` for keyed, `nth index` for unkeyed). So the per-child lookup is O(S), times S children.

This builds the lookup once per render instead - a hash keyed by `(type . key)` for keyed children, a vector for positional reuse - so each match is O(1) and reconciling the list is O(S). Reuse semantics are intentionally identical: keyed children match by key regardless of position, unkeyed match by position, first match wins on a (type, key) collision (same as the old `cl-find-if`). There's a linear fallback for the case where no lookup was built (measurement passes), so nothing relies on the fast path being present.

Measured in batch (one re-render of a keyed list, same content):

| N | before | after | speedup |
|---|--------|-------|---------|
| 250 | 30 ms | 5.7 ms | 5.3x |
| 500 | 105 ms | 11 ms | 9.2x |
| 1000 | 432 ms | 23 ms | 18.6x |
| 2000 | 1663 ms | 51 ms | 32.5x |

Before is quadratic (~4x per 2x size), after is linear (2x per 2x). The speedup widens with N because it's asymptotic, not a constant factor.

New `test/vui-reconcile-test.el` pins the reuse semantics (keyed reorder, mid-list insert, unkeyed positional). Full suite stays green with `vui-incremental-render` both off and on (555 specs).