### PR TITLE
fix: vui-unmount no longer throws on a buffer containing a field

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -25,6 +25,11 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   the named prop/state variables, =prev-props=, and =prev-state= were bound,
   so a form referencing =props= or =state= (including the documented example)
   raised =void-variable=.
+- =vui-unmount= no longer signals when tearing down a buffer that contains
+  a =vui-field=. It erased the buffer without inhibiting modification hooks,
+  so the field's =widget-after-change= ran against the half-removed field
+  and raised =(number-or-marker-p nil)=. Teardown now inhibits modification
+  hooks while erasing, as the render path already does.
 
 ** Changed
 

--- a/test/vui-unmount-test.el
+++ b/test/vui-unmount-test.el
@@ -1,0 +1,39 @@
+;;; vui-unmount-test.el --- vui-unmount teardown invariants -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Regression coverage for `vui-unmount' tearing down a buffer that
+;; contains a `vui-field'.  Unmount erases the buffer; if it does so
+;; without inhibiting modification hooks, the field's `widget-after-change'
+;; fires against a half-removed field and signals (number-or-marker-p nil).
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+(describe "vui-unmount with a field widget"
+  (it "tears down a field-containing buffer without error"
+    (let ((vui-render-delay nil))
+      (vui-defcomponent vui-um-field ()
+        :state ((v ""))
+        :render (vui-field :value v :size 10
+                           :on-change (lambda (x) (vui-set-state :v x))))
+      (let ((inst (vui-mount (vui-component 'vui-um-field) "*vui-um*")))
+        (unwind-protect
+            (progn
+              ;; Regression: this used to signal because erase-buffer fired
+              ;; the field's after-change hook during teardown.
+              (expect (vui-unmount inst) :not :to-throw)
+              ;; Buffer is kept (just erased), per the contract.
+              (expect (get-buffer "*vui-um*") :not :to-be nil)
+              (with-current-buffer "*vui-um*"
+                (expect (buffer-string) :to-equal "")))
+          (when (get-buffer "*vui-um*")
+            (with-current-buffer "*vui-um*"
+              (let ((inhibit-modification-hooks t)) (kill-buffer "*vui-um*")))))))))
+
+(provide 'vui-unmount-test)
+;;; vui-unmount-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -4616,7 +4616,13 @@ Returns the unmounted instance, or nil if nothing was mounted."
         (when (buffer-live-p buf)
           (with-current-buffer buf
             (kill-local-variable 'vui--root-instance)
-            (let ((inhibit-read-only t))
+            ;; Inhibit modification hooks while erasing: a `vui-field' in
+            ;; the buffer installs an after-change hook that runs
+            ;; `widget-after-change' against the now half-removed field and
+            ;; signals (number-or-marker-p nil).  The render path inhibits
+            ;; these hooks for the same reason; teardown must too.
+            (let ((inhibit-read-only t)
+                  (inhibit-modification-hooks t))
               (remove-overlays)
               (erase-buffer)))))
       instance))))


### PR DESCRIPTION
Found this while building a chat-style example (a buffer with an input field) for the `vui-stream` work, #82: calling `vui-unmount` on any buffer that contains a `vui-field` throws `wrong-type-argument (number-or-marker-p nil)`. Reproducible with the stock `todo-input` example too, so it's not new.

The cause: `vui-unmount` erases the buffer during teardown without binding `inhibit-modification-hooks`. The field installs an after-change hook, so `erase-buffer` fires `widget-after-change` against the field that's already being torn down, and it chokes on the now-nil markers. The render path (`vui--rerender-buffer`) already inhibits modification hooks for exactly this reason; teardown just wasn't doing the same.

One-line fix: bind `inhibit-modification-hooks` alongside `inhibit-read-only` around the teardown erase. Added a regression test that mounts a field, unmounts, and expects no signal (it fails on master, passes here). Full suite stays green.