### PR TITLE
feat: vui-stream - O(1) imperative append-only streaming (#82)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -21,10 +21,14 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   re-render re-emits the items, so the buffer stays byte-identical to what
   a plain list would render. The empty -> non-empty transition does one
   re-render (a container drops an empty child and its separator); every
-  later append is O(1). Measured in batch: appending into a 4000-item
-  stream is ~0.02ms and flat regardless of size, vs ~21ms and rising for
-  the declarative rebuild (~950x at N=4000, the gap widening with size).
-  Items are content vnodes (text) for now (#82).
+  later append is O(1). =vui-stream-update-last= rewrites just the last
+  item's region, for the in-progress message in a streaming agent UI (grow
+  it as tokens arrive): its cost depends on that one message, not on the
+  transcript length. Measured in batch: both appending into and growing the
+  last item of a 4000-item stream are ~0.02ms and flat regardless of size,
+  vs ~21ms and rising for the declarative rebuild (~950x at N=4000, the gap
+  widening with size). Items are content vnodes (text/fragment, drawn
+  however you like per item) for now (#82).
 - =:memo= keyword for =vui-defcomponent=: =:memo t= is a shorthand for the
   most common =:should-update= - skip the re-render while props are
   shallow-equal (=equal= on each value) and state is unchanged, like

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,22 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-stream= - an imperative, append-only region for unbounded streaming
+  content (chat transcripts, build logs), the one shape the declarative
+  "re-render from state" model is too slow for: it rebuilds all N items on
+  every append, so a stream of N is O(N^2). Get a handle with
+  =vui-use-stream= (or =vui-make-stream=), place it in the tree with
+  =(vui-stream handle)= so it gets a managed region, and append with
+  =(vui-stream-append handle vnode)=. An append writes exactly one region
+  in O(1) - it never re-renders or walks the existing items - and
+  declarative content below the region shifts down with it; a full
+  re-render re-emits the items, so the buffer stays byte-identical to what
+  a plain list would render. The empty -> non-empty transition does one
+  re-render (a container drops an empty child and its separator); every
+  later append is O(1). Measured in batch: appending into a 4000-item
+  stream is ~0.02ms and flat regardless of size, vs ~21ms and rising for
+  the declarative rebuild (~950x at N=4000, the gap widening with size).
+  Items are content vnodes (text) for now (#82).
 - =:memo= keyword for =vui-defcomponent=: =:memo t= is a shorthand for the
   most common =:should-update= - skip the re-render while props are
   shallow-equal (=equal= on each value) and state is unchanged, like

--- a/Eldev
+++ b/Eldev
@@ -10,5 +10,11 @@
 ;; Main package is vui.el
 (setf eldev-project-main-file "vui.el")
 
+;; Examples live in docs/examples; put that directory on `load-path' so
+;; the benchmark and test suites can (require ...) the agent-chat example
+;; under every eldev command (compile, test, emacs).  The examples
+;; themselves are not compilation targets.
+(add-to-list 'load-path (expand-file-name "docs/examples"))
+
 ;; Lint using package-lint only (skip elisp-lint style checks)
 (setf eldev-lint-default '(package))

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -45,6 +45,15 @@
 (require 'benchmark)
 (require 'cl-lib)
 
+;; The agent-chat seam example (a transcript growing above a persistent
+;; box) lives under docs/examples; load it for the streaming-seam
+;; benchmarks (`vui-bench-agent-*').  Find the project root from here.
+(let* ((here (or load-file-name buffer-file-name default-directory))
+       (root (locate-dominating-file here "vui.el")))
+  (when root
+    (add-to-list 'load-path (expand-file-name "docs/examples" root))))
+(require '13-agent-chat)
+
 ;;; Harness
 
 (defun vui-bench--ms (seconds)
@@ -422,6 +431,104 @@ thus O(n^2) to stream N (does not).  Reported wholesale vs incremental."
         (vui-unmount inst)
         (when (get-buffer buf) (kill-buffer buf))))))
 
+;;; Agent-chat streaming seam (issue #82, dir 5: vui-stream)
+;;
+;; The pi.el-shaped case WITH the hard part: a transcript that grows
+;; above a persistent declarative box (status + input field).  Two costs
+;; matter, both O(n) today and both targets for `vui-stream':
+;;
+;;   append-growth  (Path 1): cost of appending one message vs size S.
+;;     The stream owns its region and should append in O(1) -> FLAT
+;;     slope.  Today the transcript is a plain vstack rebuilt every
+;;     render -> rising slope (O(n) per append, O(n^2) to stream N).
+;;
+;;   box-update     (Path 2): cost of a box-only state change (status)
+;;     vs size S.  Once the stream node is opaque to reconcile this
+;;     should be O(box), independent of S -> FLAT.  Today a box change
+;;     re-renders the whole transcript too -> rising slope.
+;;
+;; These establish the "before" numbers.  When `vui-stream' lands, both
+;; slopes must flatten while the buffer stays byte-identical to the
+;; wholesale baseline (the oracle in test/vui-agent-chat-test.el).
+
+(defun vui-bench--agent-messages (n)
+  "Return N agent-chat messages cycling through the three roles."
+  (cl-loop for i from 1 to n
+           collect (list :id i
+                         :role (nth (mod i 3) '(user agent tool))
+                         :text (format "message %d content" i))))
+
+(defun vui-bench--agent-teardown (inst buf)
+  "Unmount INST and kill BUF, tolerating the field-widget unmount caveat."
+  (let ((inhibit-modification-hooks t))
+    (ignore-errors (vui-unmount inst)))
+  (when (get-buffer buf)
+    (let ((inhibit-modification-hooks t)) (kill-buffer buf))))
+
+(defun vui-bench-agent-append-growth ()
+  "Cost of appending ONE message as the agent-chat transcript grows.
+The chat box (status + input field) sits BELOW the transcript, so this
+measures the real seam, not a bare append-only log.  A flat slope means
+O(1) append (the `vui-stream' target); a rising slope means O(n) per
+append.  Reported wholesale vs incremental."
+  (vui-bench--header "Agent-chat append: +1 msg at transcript size S (box below)")
+  (dolist (s '(200 500 1000 2000 4000))
+    (dolist (flag '((nil . "wholesale") (t . "incremental")))
+      (let* ((vui-incremental-render (car flag))
+             (base (vui-bench--agent-messages s))
+             (plus (append base (list (list :id (1+ s) :role 'agent
+                                            :text "freshly streamed line"))))
+             (buf "*vui-bench-agent-sg*")
+             (inst (vui-mount (vui-component 'vui-agent-chat
+                               :messages base :queue 0 :status "idle")
+                              buf))
+             (tog nil))
+        (vui-update inst (list :messages base :queue 0 :status "idle"))
+        (vui-bench--result-row
+         (format "%d %s" s (cdr flag))
+         (vui-bench--measure
+          5 (lambda () (setq tog (not tog))
+              (vui-update inst (list :messages (if tog plus base)
+                                     :queue 0 :status "idle")))))
+        (vui-bench--agent-teardown inst buf)))))
+
+(defun vui-bench-agent-box-update ()
+  "Cost of a BOX-ONLY state change as the transcript grows.
+Toggles the box status while the transcript stays fixed at size S.  The
+box change costs O(box), but today it re-renders the whole transcript
+too, so the slope rises; with `vui-stream' the transcript is opaque to
+this re-render and the slope should go flat.  Wholesale vs incremental."
+  (vui-bench--header "Agent-chat box update: toggle status at transcript size S")
+  (dolist (s '(200 500 1000 2000 4000))
+    (dolist (flag '((nil . "wholesale") (t . "incremental")))
+      (let* ((vui-incremental-render (car flag))
+             (msgs (vui-bench--agent-messages s))
+             (buf "*vui-bench-agent-box*")
+             (inst (vui-mount (vui-component 'vui-agent-chat
+                               :messages msgs :queue 0 :status "idle")
+                              buf))
+             (tog nil))
+        (vui-update inst (list :messages msgs :queue 0 :status "idle"))
+        (vui-bench--result-row
+         (format "%d %s" s (cdr flag))
+         (vui-bench--measure
+          5 (lambda () (setq tog (not tog))
+              (vui-update inst (list :messages msgs :queue (if tog 1 0)
+                                     :status (if tog "busy" "idle"))))))
+        (vui-bench--agent-teardown inst buf)))))
+
+(defun vui-bench-agent-run ()
+  "Run only the agent-chat streaming-seam benchmarks."
+  (interactive)
+  (let ((vui-render-delay nil)
+        (vui-timing-enabled nil)
+        (vui-debug-enabled nil))
+    (message "VUI agent-chat seam (Emacs %s)" emacs-version)
+    (vui-bench-agent-append-growth)
+    (vui-bench-agent-box-update)
+    (message "")
+    (message "done.")))
+
 ;;; Cross-version / cross-flag comparison
 ;;
 ;; Answers three questions with one matrix, on whatever build is loaded
@@ -656,6 +763,8 @@ machine-readable CMPDATA lines."
     (vui-bench-widgets)
     (vui-bench-component-bailout)
     (vui-bench-streaming-growth)
+    (vui-bench-agent-append-growth)
+    (vui-bench-agent-box-update)
     (message "")
     (message "done.")))
 

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -46,12 +46,8 @@
 (require 'cl-lib)
 
 ;; The agent-chat seam example (a transcript growing above a persistent
-;; box) lives under docs/examples; load it for the streaming-seam
-;; benchmarks (`vui-bench-agent-*').  Find the project root from here.
-(let* ((here (or load-file-name buffer-file-name default-directory))
-       (root (locate-dominating-file here "vui.el")))
-  (when root
-    (add-to-list 'load-path (expand-file-name "docs/examples" root))))
+;; box) drives the streaming-seam benchmarks (`vui-bench-agent-*' and the
+;; `vui-stream' ones).  The Eldev file puts docs/examples on `load-path'.
 (require '13-agent-chat)
 
 ;;; Harness

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -544,6 +544,28 @@ append, independent of stream size - contrast the rising slope of
         8 (lambda () (vui-stream-append handle (vui-text "freshly streamed line")))))
       (vui-bench--agent-teardown inst buf))))
 
+(defun vui-bench-stream-update-last-growth ()
+  "Cost of one `vui-stream-update-last' as the stream grows, box below.
+The per-token path of a streaming agent UI (the in-progress message grows
+word by word).  A FLAT slope means the update is independent of transcript
+size - only the last item's region is rewritten."
+  (vui-bench--header "Stream update-last: grow last item at stream size S (box below)")
+  (dolist (s '(200 500 1000 2000 4000))
+    (let* ((handle (vui-make-stream))
+           (buf "*vui-bench-stream-ul*")
+           (inst (vui-mount (vui-component 'vui-bench-stream-app :stream handle) buf))
+           (k 0))
+      (dotimes (i s)
+        (vui-stream-append handle (vui-text (format "message %d content" i))))
+      (vui-stream-append handle (vui-text "in progress"))
+      (vui-bench--result-row
+       (format "%d stream" s)
+       (vui-bench--measure
+        8 (lambda () (setq k (1+ k))
+            (vui-stream-update-last
+             handle (vui-text (format "growing message token %d here" k))))))
+      (vui-bench--agent-teardown inst buf))))
+
 (defun vui-bench-agent-run ()
   "Run the streaming-seam benchmarks (declarative baseline + vui-stream)."
   (interactive)
@@ -554,6 +576,7 @@ append, independent of stream size - contrast the rising slope of
     (vui-bench-agent-append-growth)
     (vui-bench-agent-box-update)
     (vui-bench-stream-append-growth)
+    (vui-bench-stream-update-last-growth)
     (message "")
     (message "done.")))
 
@@ -794,6 +817,7 @@ machine-readable CMPDATA lines."
     (vui-bench-agent-append-growth)
     (vui-bench-agent-box-update)
     (vui-bench-stream-append-growth)
+    (vui-bench-stream-update-last-growth)
     (message "")
     (message "done.")))
 

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -517,15 +517,43 @@ this re-render and the slope should go flat.  Wholesale vs incremental."
                                      :status (if tog "busy" "idle"))))))
         (vui-bench--agent-teardown inst buf)))))
 
+;; The imperative counterpart: a `vui-stream' above a box line.  Appends
+;; go through `vui-stream-append', which owns the region and writes one
+;; spot in O(1) - so this slope should be FLAT where the declarative
+;; agent-append-growth above rises.
+(vui-defcomponent vui-bench-stream-app (stream)
+  :render (vui-vstack (vui-stream stream)
+                      (vui-text "---- input box ----")))
+
+(defun vui-bench-stream-append-growth ()
+  "Cost of ONE `vui-stream-append' as the stream grows, box below.
+The pass/fail metric for vui-stream (#82): a FLAT slope means O(1)
+append, independent of stream size - contrast the rising slope of
+`vui-bench-agent-append-growth', which rebuilds the transcript."
+  (vui-bench--header "Stream append: +1 item at stream size S (box below)")
+  (dolist (s '(200 500 1000 2000 4000))
+    (let* ((handle (vui-make-stream))
+           (buf "*vui-bench-stream*")
+           (inst (vui-mount (vui-component 'vui-bench-stream-app :stream handle) buf)))
+      ;; pre-fill (the first item pays a one-time re-render, the rest O(1))
+      (dotimes (i s)
+        (vui-stream-append handle (vui-text (format "message %d content" i))))
+      (vui-bench--result-row
+       (format "%d stream" s)
+       (vui-bench--measure
+        8 (lambda () (vui-stream-append handle (vui-text "freshly streamed line")))))
+      (vui-bench--agent-teardown inst buf))))
+
 (defun vui-bench-agent-run ()
-  "Run only the agent-chat streaming-seam benchmarks."
+  "Run the streaming-seam benchmarks (declarative baseline + vui-stream)."
   (interactive)
   (let ((vui-render-delay nil)
         (vui-timing-enabled nil)
         (vui-debug-enabled nil))
-    (message "VUI agent-chat seam (Emacs %s)" emacs-version)
+    (message "VUI streaming seam (Emacs %s)" emacs-version)
     (vui-bench-agent-append-growth)
     (vui-bench-agent-box-update)
+    (vui-bench-stream-append-growth)
     (message "")
     (message "done.")))
 
@@ -765,6 +793,7 @@ machine-readable CMPDATA lines."
     (vui-bench-streaming-growth)
     (vui-bench-agent-append-growth)
     (vui-bench-agent-box-update)
+    (vui-bench-stream-append-growth)
     (message "")
     (message "done.")))
 

--- a/docs/examples/13-agent-chat.el
+++ b/docs/examples/13-agent-chat.el
@@ -1,0 +1,135 @@
+;;; 13-agent-chat.el --- Agent chat UI (streaming seam example) -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; A small agent-chat UI used as the running example for the imperative
+;; append primitive (`vui-stream', issue #82 dir 5).  It is shaped like
+;; the case that stresses the seam: an ever-growing transcript ABOVE a
+;; persistent declarative box that must stay present and functional no
+;; matter how many messages stream in.
+;;
+;;   +---------------------------------+
+;;   | transcript (grows downward)     |
+;;   |   you> ...        (user)        |
+;;   |   ai>  ...        (agent)       |
+;;   |     [tool] ...    (tool)        |
+;;   +------------- box ---------------+
+;;   | status / queue                  |
+;;   | [ input field widget ]          |
+;;   +---------------------------------+
+;;
+;; This is the DECLARATIVE BASELINE: the transcript is a plain
+;; `vui-vstack' rebuilt every render, so an append is O(n) and streaming
+;; is O(n^2).  It is the correctness oracle and the "before" benchmark
+;; that `vui-stream' must match byte-for-byte while flattening the slope.
+;;
+;; The components are intentionally prop-driven (the transcript is a
+;; `:messages' prop) so tests and benchmarks can drive growth with
+;; `vui-update'.  `vui-agent-chat-demo' wraps them with internal state
+;; and a timer to simulate async agent output for interactive use.
+
+;;; Code:
+
+(require 'vui)
+(require 'cl-lib)
+
+;;; Message - drawn differently per role
+
+(vui-defcomponent vui-chat-message (id role text)
+  "One transcript message, rendered differently depending on ROLE."
+  :render
+  (pcase role
+    ('user  (vui-text (concat "you> " text) :face 'bold))
+    ('agent (vui-text (concat "ai>  " text)))
+    ('tool  (vui-text (concat "  [tool] " text) :face 'shadow))
+    (_      (vui-text text))))
+
+;;; Transcript - the O(n) part vui-stream will replace
+
+(vui-defcomponent vui-chat-transcript (messages)
+  "Render MESSAGES (a list of plists) as a vertical transcript.
+Built with a plain `mapcar' + `vui-vstack', so every render rebuilds
+all N message vnodes.  This is the cost vui-stream removes."
+  :render
+  (if (null messages)
+      (vui-text "(no messages yet)" :face 'shadow)
+    (apply #'vui-vstack
+           (mapcar (lambda (m)
+                     (vui-component 'vui-chat-message
+                       :key (plist-get m :id)
+                       :id (plist-get m :id)
+                       :role (plist-get m :role)
+                       :text (plist-get m :text)))
+                   messages))))
+
+;;; Chat box - the persistent declarative part below the transcript
+
+(vui-defcomponent vui-chat-box (queue status)
+  "The bottom box: a separator, a status/queue line, and an input field.
+Holds its own draft text in local state, so typing does not depend on
+the transcript above it."
+  :state ((draft ""))
+  :render
+  (vui-vstack
+   (vui-text (make-string 40 ?-) :face 'shadow)
+   (vui-text (format "status: %s   queue: %d pending"
+                     (or status "idle") (or queue 0))
+     :face 'font-lock-comment-face)
+   (vui-field :value draft
+              :size 40
+              :placeholder "Type a message..."
+              :on-change (lambda (v) (vui-set-state :draft v)))))
+
+;;; Root - transcript above, box below
+
+(vui-defcomponent vui-agent-chat (messages queue status)
+  "Agent chat: a growing MESSAGES transcript above a persistent box.
+QUEUE and STATUS feed the box.  Prop-driven so growth can be simulated
+with `vui-update'."
+  :render
+  (vui-vstack
+   (vui-component 'vui-chat-transcript :messages messages)
+   (vui-component 'vui-chat-box :queue queue :status status)))
+
+;;; Interactive demo - simulate async agent streaming with a timer
+
+(defun vui-agent-chat--roles (i)
+  "Cycle a role symbol for message index I."
+  (nth (mod i 3) '(user agent tool)))
+
+(vui-defcomponent vui-agent-chat-demo (interval)
+  "Drive `vui-agent-chat', appending a fake message every INTERVAL seconds.
+Watch the box stay put and the field stay editable as the transcript
+grows.  INTERVAL defaults to 0.5."
+  :state ((messages nil) (queue 0) (status "idle"))
+  :render
+  (progn
+    ;; Append one message per tick.  Functional `vui-set-state' updates
+    ;; avoid capturing stale state in the timer closure.
+    (vui-use-effect ()
+      (let ((timer (run-with-timer
+                    (or interval 0.5) (or interval 0.5)
+                    (vui-with-async-context
+                     (vui-set-state
+                      :messages
+                      (lambda (old)
+                        (let ((n (1+ (length old))))
+                          (append old
+                                  (list (list :id n
+                                              :role (vui-agent-chat--roles n)
+                                              :text (format "streamed message %d" n)))))))))))
+        (lambda () (cancel-timer timer))))
+    (vui-component 'vui-agent-chat
+      :messages messages :queue queue :status status)))
+
+;;;###autoload
+(defun vui-example-agent-chat ()
+  "Run the agent-chat streaming demo."
+  (interactive)
+  (vui-mount (vui-component 'vui-agent-chat-demo :interval 0.5)
+             "*vui-agent-chat*"))
+
+(provide '13-agent-chat)
+;;; 13-agent-chat.el ends here

--- a/docs/examples/13-agent-chat.el
+++ b/docs/examples/13-agent-chat.el
@@ -37,14 +37,19 @@
 
 ;;; Message - drawn differently per role
 
-(vui-defcomponent vui-chat-message (id role text)
-  "One transcript message, rendered differently depending on ROLE."
-  :render
+(defun vui-chat-message-vnode (role text)
+  "Return a content vnode rendering TEXT for ROLE, drawn per role.
+Shared by the declarative `vui-chat-message' component and the streaming
+transcript, so a message renders identically whichever path emits it."
   (pcase role
     ('user  (vui-text (concat "you> " text) :face 'bold))
     ('agent (vui-text (concat "ai>  " text)))
     ('tool  (vui-text (concat "  [tool] " text) :face 'shadow))
     (_      (vui-text text))))
+
+(vui-defcomponent vui-chat-message (id role text)
+  "One transcript message, rendered differently depending on ROLE."
+  :render (vui-chat-message-vnode role text))
 
 ;;; Transcript - the O(n) part vui-stream will replace
 
@@ -93,6 +98,18 @@ with `vui-update'."
    (vui-component 'vui-chat-transcript :messages messages)
    (vui-component 'vui-chat-box :queue queue :status status)))
 
+;;; Streaming root - the SAME UI, transcript driven by `vui-stream'
+
+(vui-defcomponent vui-agent-chat-stream (stream queue status)
+  "Agent chat whose transcript is a `vui-stream' (handle STREAM).
+Identical output to `vui-agent-chat', but messages are appended
+imperatively with `vui-stream-append' (O(1)) instead of rebuilt from a
+:messages prop.  QUEUE and STATUS feed the same persistent box below."
+  :render
+  (vui-vstack
+   (vui-stream stream)
+   (vui-component 'vui-chat-box :queue queue :status status)))
+
 ;;; Interactive demo - simulate async agent streaming with a timer
 
 (defun vui-agent-chat--roles (i)
@@ -124,12 +141,42 @@ grows.  INTERVAL defaults to 0.5."
     (vui-component 'vui-agent-chat
       :messages messages :queue queue :status status)))
 
+(vui-defcomponent vui-agent-chat-stream-demo (interval)
+  "Stream a fake message every INTERVAL seconds via `vui-stream-append'.
+The transcript grows in O(1) per message while the box below stays put
+and editable.  INTERVAL defaults to 0.5."
+  :state ((queue 0) (status "idle"))
+  :render
+  (let ((stream (vui-use-stream)))
+    ;; Append imperatively on each tick.  The message number comes from
+    ;; the stream's own length, so the timer closure needs no live state.
+    (vui-use-effect ()
+      (let ((timer (run-with-timer
+                    (or interval 0.5) (or interval 0.5)
+                    (vui-with-async-context
+                     (let ((n (1+ (length (vui-stream-handle-items-rev stream)))))
+                       (vui-stream-append
+                        stream
+                        (vui-chat-message-vnode
+                         (vui-agent-chat--roles n)
+                         (format "streamed message %d" n))))))))
+        (lambda () (cancel-timer timer))))
+    (vui-component 'vui-agent-chat-stream
+      :stream stream :queue queue :status status)))
+
 ;;;###autoload
 (defun vui-example-agent-chat ()
-  "Run the agent-chat streaming demo."
+  "Run the agent-chat streaming demo (declarative transcript)."
   (interactive)
   (vui-mount (vui-component 'vui-agent-chat-demo :interval 0.5)
              "*vui-agent-chat*"))
+
+;;;###autoload
+(defun vui-example-agent-chat-stream ()
+  "Run the agent-chat demo with a `vui-stream' transcript (O(1) appends)."
+  (interactive)
+  (vui-mount (vui-component 'vui-agent-chat-stream-demo :interval 0.5)
+             "*vui-agent-chat-stream*"))
 
 (provide '13-agent-chat)
 ;;; 13-agent-chat.el ends here

--- a/docs/examples/13-agent-chat.el
+++ b/docs/examples/13-agent-chat.el
@@ -141,26 +141,49 @@ grows.  INTERVAL defaults to 0.5."
     (vui-component 'vui-agent-chat
       :messages messages :queue queue :status status)))
 
+(defvar vui-agent-chat--script
+  '((user  . "what's the weather like today?")
+    (agent . "Let me check the forecast for you right now.")
+    (tool  . "weather.get(location = here)")
+    (agent . "It looks sunny with a high around 24 degrees - a great day."))
+  "Scripted messages for the streaming demo, typed out word by word.")
+
 (vui-defcomponent vui-agent-chat-stream-demo (interval)
-  "Stream a fake message every INTERVAL seconds via `vui-stream-append'.
-The transcript grows in O(1) per message while the box below stays put
-and editable.  INTERVAL defaults to 0.5."
+  "Simulate an agent typing messages token-by-token over `vui-stream'.
+Each scripted message is appended on its first word, then grown one word
+at a time with `vui-stream-update-last' (so the in-progress message
+updates in place), then the next message begins.  The transcript and the
+box below never re-render during this - only the last line changes.
+INTERVAL defaults to 0.25."
   :state ((queue 0) (status "idle"))
   :render
   (let ((stream (vui-use-stream)))
-    ;; Append imperatively on each tick.  The message number comes from
-    ;; the stream's own length, so the timer closure needs no live state.
     (vui-use-effect ()
-      (let ((timer (run-with-timer
-                    (or interval 0.5) (or interval 0.5)
-                    (vui-with-async-context
-                     (let ((n (1+ (length (vui-stream-handle-items-rev stream)))))
-                       (vui-stream-append
+      ;; Mutable cursor over the script, captured by the timer.  wi = 0
+      ;; means "start the next message"; later words grow it in place.
+      (let ((mi 0) (wi 0)
+            (script vui-agent-chat--script))
+        (let ((timer
+               (run-with-timer
+                (or interval 0.25) (or interval 0.25)
+                (vui-with-async-context
+                 (when (< mi (length script))
+                   (let* ((msg (nth mi script))
+                          (role (car msg))
+                          (words (split-string (cdr msg) " ")))
+                     (if (= wi 0)
+                         ;; first word: append a new message
+                         (vui-stream-append
+                          stream (vui-chat-message-vnode role (car words)))
+                       ;; later words: grow the in-progress message in place
+                       (vui-stream-update-last
                         stream
                         (vui-chat-message-vnode
-                         (vui-agent-chat--roles n)
-                         (format "streamed message %d" n))))))))
-        (lambda () (cancel-timer timer))))
+                         role (string-join (cl-subseq words 0 (1+ wi)) " "))))
+                     (setq wi (1+ wi))
+                     (when (>= wi (length words))
+                       (setq mi (1+ mi) wi 0))))))))
+          (lambda () (cancel-timer timer)))))
     (vui-component 'vui-agent-chat-stream
       :stream stream :queue queue :status status)))
 

--- a/test/vui-agent-chat-test.el
+++ b/test/vui-agent-chat-test.el
@@ -26,12 +26,8 @@
 (require 'vui)
 (require 'cl-lib)
 
-;; The example app lives under docs/examples; put it on the load path by
-;; finding the project root (the directory holding vui.el) from here.
-(let* ((here (or load-file-name buffer-file-name default-directory))
-       (root (locate-dominating-file here "vui.el")))
-  (when root
-    (add-to-list 'load-path (expand-file-name "docs/examples" root))))
+;; The example app lives under docs/examples, which the Eldev file puts
+;; on `load-path' for every eldev command.
 (require '13-agent-chat)
 
 (defun vui-agent--kill (buf)

--- a/test/vui-agent-chat-test.el
+++ b/test/vui-agent-chat-test.el
@@ -1,0 +1,159 @@
+;;; vui-agent-chat-test.el --- Agent-chat streaming seam invariants -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Correctness invariants for the agent-chat example (docs/examples/
+;; 13-agent-chat.el), the running case for the `vui-stream' imperative
+;; append primitive (issue #82, dir 5).
+;;
+;; The layout is the seam that stresses imperative-inside-declarative: a
+;; transcript that grows ABOVE a persistent box whose input field must
+;; stay present and correct no matter how many messages arrive.
+;;
+;; These run against the DECLARATIVE BASELINE (no `vui-stream' yet), so
+;; they pass today.  Their job is twofold:
+;;   1. pin the baseline behavior (box present, roles drawn distinctly);
+;;   2. establish the ORACLE: growing by `vui-update' is byte-identical
+;;      to a fresh mount of the final message list.  When `vui-stream'
+;;      lands, the stream-built buffer must match this same oracle
+;;      (`vui-agent--string'), which is the differential check.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+(require 'cl-lib)
+
+;; The example app lives under docs/examples; put it on the load path by
+;; finding the project root (the directory holding vui.el) from here.
+(let* ((here (or load-file-name buffer-file-name default-directory))
+       (root (locate-dominating-file here "vui.el")))
+  (when root
+    (add-to-list 'load-path (expand-file-name "docs/examples" root))))
+(require '13-agent-chat)
+
+(defun vui-agent--kill (buf)
+  "Kill BUF, tolerating field widgets (see the unmount caveat)."
+  (when (get-buffer buf)
+    (with-current-buffer buf
+      (let ((inhibit-modification-hooks t))
+        (kill-buffer buf)))))
+
+(defun vui-agent--messages (n)
+  "Return N demo messages cycling through the three roles."
+  (cl-loop for i from 1 to n
+           collect (list :id i
+                         :role (nth (mod i 3) '(user agent tool))
+                         :text (format "m%d" i))))
+
+(defun vui-agent--string (messages queue status)
+  "Buffer string of a FRESH mount of `vui-agent-chat'.
+This is the oracle: the canonical rendering of MESSAGES/QUEUE/STATUS
+that any incremental path must reproduce byte-for-byte."
+  (let* ((buf "*vui-agent-oracle*")
+         (inst (vui-mount (vui-component 'vui-agent-chat
+                            :messages messages :queue queue :status status)
+                          buf)))
+    (ignore inst)
+    (prog1 (with-current-buffer buf (buffer-string))
+      (vui-agent--kill buf))))
+
+(describe "agent-chat baseline: messages drawn per role"
+  (it "renders user, agent, and tool messages distinctly"
+    (let* ((vui-render-delay nil)
+           (s (vui-agent--string
+               '((:id 1 :role user  :text "hi")
+                 (:id 2 :role agent :text "hello")
+                 (:id 3 :role tool  :text "ran"))
+               0 "idle")))
+      (expect s :to-match "you> hi")
+      (expect s :to-match "ai>  hello")
+      (expect s :to-match "\\[tool\\] ran"))))
+
+(describe "agent-chat baseline: the box is always present"
+  (it "renders status, queue, and an input field below the transcript"
+    (let* ((vui-render-delay nil)
+           (buf "*vui-agent-box*")
+           (inst (vui-mount (vui-component 'vui-agent-chat
+                              :messages (vui-agent--messages 5)
+                              :queue 3 :status "thinking")
+                            buf)))
+      (ignore inst)
+      (unwind-protect
+          (with-current-buffer buf
+            (expect (buffer-string) :to-match "status: thinking")
+            (expect (buffer-string) :to-match "queue: 3 pending")
+            ;; the field widget really exists (placeholder is an overlay,
+            ;; not buffer text, so assert on the widget list instead)
+            (expect widget-field-list :not :to-be nil))
+        (vui-agent--kill buf))))
+
+  (it "keeps the box present and correct after many appends"
+    (let* ((vui-render-delay nil)
+           (buf "*vui-agent-grow-box*")
+           (base (vui-agent--messages 1))
+           (inst (vui-mount (vui-component 'vui-agent-chat
+                              :messages base :queue 0 :status "idle")
+                            buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            ;; stream 200 messages in, one at a time
+            (let ((msgs base))
+              (dotimes (i 200)
+                (setq msgs (append msgs
+                                   (list (list :id (+ 2 i)
+                                               :role 'agent
+                                               :text (format "x%d" i)))))
+                (vui-update inst (list :messages msgs :queue 0 :status "idle"))))
+            (with-current-buffer buf
+              ;; box still there, still has its field, after 200 appends
+              (expect (buffer-string) :to-match "status: idle")
+              (expect (buffer-string) :to-match "queue: 0 pending")
+              (expect widget-field-list :not :to-be nil)))
+        (vui-agent--kill buf)))))
+
+(describe "agent-chat baseline: the growth oracle"
+  ;; The load-bearing invariant for vui-stream: growing the transcript
+  ;; by `vui-update' must produce exactly what a fresh mount of the final
+  ;; list produces.  This pins order-independence and gives the stream
+  ;; path its differential target.
+  (it "grows byte-identically to a fresh mount (single append)"
+    (let* ((vui-render-delay nil)
+           (base (vui-agent--messages 10))
+           (grown (append base (list (list :id 11 :role 'user :text "m11"))))
+           (buf "*vui-agent-grow1*")
+           (inst (vui-mount (vui-component 'vui-agent-chat
+                              :messages base :queue 0 :status "idle")
+                            buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (vui-update inst (list :messages grown :queue 0 :status "idle"))
+            (expect (with-current-buffer buf (buffer-string))
+                    :to-equal (vui-agent--string grown 0 "idle")))
+        (vui-agent--kill buf))))
+
+  (it "grows byte-identically across a long stream"
+    (let* ((vui-render-delay nil)
+           (buf "*vui-agent-grow-n*")
+           (msgs (vui-agent--messages 1))
+           (inst (vui-mount (vui-component 'vui-agent-chat
+                              :messages msgs :queue 2 :status "busy")
+                            buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (dotimes (i 50)
+              (setq msgs (append msgs
+                                 (list (list :id (+ 2 i) :role 'tool
+                                             :text (format "t%d" i)))))
+              (vui-update inst (list :messages msgs :queue 2 :status "busy")))
+            (expect (with-current-buffer buf (buffer-string))
+                    :to-equal (vui-agent--string msgs 2 "busy")))
+        (vui-agent--kill buf)))))
+
+(provide 'vui-agent-chat-test)
+;;; vui-agent-chat-test.el ends here

--- a/test/vui-agent-chat-test.el
+++ b/test/vui-agent-chat-test.el
@@ -155,5 +155,44 @@ that any incremental path must reproduce byte-for-byte."
                     :to-equal (vui-agent--string msgs 2 "busy")))
         (vui-agent--kill buf)))))
 
+(describe "agent-chat: the streaming transcript matches the declarative UI"
+  ;; The vui-stream version must render byte-identically to the wholesale
+  ;; vui-agent-chat oracle - same messages, same box.
+  (it "appends messages via vui-stream to the same buffer as a fresh mount"
+    (let* ((vui-render-delay nil)
+           (s (vui-make-stream))
+           (msgs (vui-agent--messages 25))
+           (buf "*vui-agent-stream*")
+           (inst (vui-mount (vui-component 'vui-agent-chat-stream
+                              :stream s :queue 2 :status "busy")
+                            buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (dolist (m msgs)
+              (vui-stream-append
+               s (vui-chat-message-vnode (plist-get m :role) (plist-get m :text))))
+            (expect (with-current-buffer buf (buffer-string))
+                    :to-equal (vui-agent--string msgs 2 "busy")))
+        (vui-agent--kill buf))))
+
+  (it "keeps the box (field + status) correct as the stream grows"
+    (let* ((vui-render-delay nil)
+           (s (vui-make-stream))
+           (buf "*vui-agent-stream-box*")
+           (inst (vui-mount (vui-component 'vui-agent-chat-stream
+                              :stream s :queue 0 :status "idle")
+                            buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (dotimes (i 150)
+              (vui-stream-append s (vui-chat-message-vnode 'agent (format "m%d" i))))
+            (with-current-buffer buf
+              (expect (buffer-string) :to-match "status: idle")
+              (expect (buffer-string) :to-match "queue: 0 pending")
+              (expect widget-field-list :not :to-be nil)))
+        (vui-agent--kill buf)))))
+
 (provide 'vui-agent-chat-test)
 ;;; vui-agent-chat-test.el ends here

--- a/test/vui-stream-test.el
+++ b/test/vui-stream-test.el
@@ -1,0 +1,137 @@
+;;; vui-stream-test.el --- vui-stream imperative append invariants -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Phase 1 invariants for `vui-stream' (issue #82, dir 5): an append-only
+;; region that grows ABOVE a persistent declarative line.  The point of
+;; the primitive is an O(1) imperative append, but the bar is correctness:
+;;
+;;   - after any sequence of appends the buffer is BYTE-IDENTICAL to what a
+;;     plain list of the same items would render (the oracle);
+;;   - the declarative content BELOW the stream stays correct as the stream
+;;     grows (it just shifts down);
+;;   - a full re-render (a sibling's state change) re-emits the items, so
+;;     the wholesale path matches the oracle too;
+;;   - point below the stream is preserved across an append above it.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+;; A stream above a declarative note line.  The handle is passed in as a
+;; prop so the test owns it and can append imperatively.
+(vui-defcomponent vui-st-app (stream note)
+  :render
+  (vui-vstack
+   (vui-stream stream)
+   (vui-text (format "note: %s" (or note "")))))
+
+(defun vui-st--oracle (lines note)
+  "Expected buffer string: LINES stacked above the NOTE line.
+With no lines the stream is an empty vstack child and is dropped (no
+leading separator), matching what a plain declarative list renders."
+  (if lines
+      (concat (mapconcat #'identity lines "\n") "\nnote: " note)
+    (concat "note: " note)))
+
+(defun vui-st--mount (stream note)
+  (vui-mount (vui-component 'vui-st-app :stream stream :note note) "*vui-st*"))
+
+(defun vui-st--buffer ()
+  (with-current-buffer "*vui-st*" (buffer-string)))
+
+(defun vui-st--kill ()
+  (when (get-buffer "*vui-st*") (kill-buffer "*vui-st*")))
+
+(describe "vui-stream: append is byte-identical to the oracle"
+  (it "matches a plain list after a sequence of appends"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "n0")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              (vui-stream-append s (vui-text "line 1"))
+              (vui-stream-append s (vui-text "line 2"))
+              (vui-stream-append s (vui-text "line 3"))
+              (expect (vui-st--buffer)
+                      :to-equal (vui-st--oracle '("line 1" "line 2" "line 3") "n0")))
+          (vui-st--kill)))))
+
+  (it "handles the empty stream and the first append (no leading newline)"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "hi")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              ;; nothing appended yet: just the note, below an empty region
+              (expect (vui-st--buffer) :to-equal (vui-st--oracle '() "hi"))
+              (vui-stream-append s (vui-text "first"))
+              (expect (vui-st--buffer) :to-equal (vui-st--oracle '("first") "hi")))
+          (vui-st--kill))))))
+
+(describe "vui-stream: the line below stays correct as the stream grows"
+  (it "keeps the note intact and in place across 100 appends"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "footer")))
+        (ignore inst)
+        (unwind-protect
+            (let (lines)
+              (dotimes (i 100)
+                (let ((txt (format "msg %d" i)))
+                  (push txt lines)
+                  (vui-stream-append s (vui-text txt))))
+              (setq lines (nreverse lines))
+              (expect (vui-st--buffer) :to-equal (vui-st--oracle lines "footer"))
+              ;; the note line is still present, exactly once, at the bottom
+              (with-current-buffer "*vui-st*"
+                (goto-char (point-min))
+                (expect (how-many "^note: footer$") :to-equal 1)
+                (goto-char (point-max))
+                (expect (line-number-at-pos)
+                        :to-equal (1+ (length lines)))))
+          (vui-st--kill))))))
+
+(describe "vui-stream: a full re-render re-emits identically"
+  (it "matches the oracle after a sibling state change rebuilds the buffer"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "n0")))
+        (unwind-protect
+            (progn
+              (vui-stream-append s (vui-text "a"))
+              (vui-stream-append s (vui-text "b"))
+              ;; change the note prop: forces a wholesale root re-render,
+              ;; which must re-emit the stream items from the handle
+              (vui-update inst (list :stream s :note "n1"))
+              (expect (vui-st--buffer) :to-equal (vui-st--oracle '("a" "b") "n1"))
+              ;; appends after a re-render keep working
+              (vui-stream-append s (vui-text "c"))
+              (expect (vui-st--buffer) :to-equal (vui-st--oracle '("a" "b" "c") "n1")))
+          (vui-st--kill))))))
+
+(describe "vui-stream: point below the stream is preserved on append"
+  (it "leaves point in the note line after an append above it"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "tail")))
+        (ignore inst)
+        (unwind-protect
+            (with-current-buffer "*vui-st*"
+              (vui-stream-append s (vui-text "x"))
+              ;; put point on the 'l' of "tail"
+              (goto-char (point-max))
+              (let ((before (char-before)))
+                (vui-stream-append s (vui-text "y"))
+                ;; point still at end of buffer, still after the same char
+                (expect (point) :to-equal (point-max))
+                (expect (char-before) :to-equal before)))
+          (vui-st--kill))))))
+
+(provide 'vui-stream-test)
+;;; vui-stream-test.el ends here

--- a/test/vui-stream-test.el
+++ b/test/vui-stream-test.el
@@ -133,5 +133,79 @@ leading separator), matching what a plain declarative list renders."
                 (expect (char-before) :to-equal before)))
           (vui-st--kill))))))
 
+(describe "vui-stream: update-last grows the in-progress item in place"
+  (it "matches the oracle after updating the last item (token streaming)"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "n0")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              (vui-stream-append s (vui-text "line 1"))
+              (vui-stream-append s (vui-text "par"))      ; in-progress msg
+              ;; tokens arrive: re-render the last item with the message so far
+              (vui-stream-update-last s (vui-text "partial"))
+              (vui-stream-update-last s (vui-text "partial response"))
+              (vui-stream-update-last s (vui-text "partial response done"))
+              (expect (vui-st--buffer)
+                      :to-equal
+                      (vui-st--oracle '("line 1" "partial response done") "n0")))
+          (vui-st--kill)))))
+
+  (it "works on the very first item (which took the re-render path)"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "hi")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              (vui-stream-append s (vui-text "first"))    ; empty -> non-empty
+              (vui-stream-update-last s (vui-text "first updated"))
+              (expect (vui-st--buffer)
+                      :to-equal (vui-st--oracle '("first updated") "hi")))
+          (vui-st--kill)))))
+
+  (it "appends correctly after an update-last (continue the stream)"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "z")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              (vui-stream-append s (vui-text "a"))
+              (vui-stream-update-last s (vui-text "aa"))
+              (vui-stream-append s (vui-text "b"))
+              (vui-stream-update-last s (vui-text "bb"))
+              (expect (vui-st--buffer)
+                      :to-equal (vui-st--oracle '("aa" "bb") "z")))
+          (vui-st--kill)))))
+
+  (it "leaves the line below correct after an update-last"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "footer")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              (dotimes (i 50) (vui-stream-append s (vui-text (format "m%d" i))))
+              (vui-stream-update-last s (vui-text "m49 GROWN with more text"))
+              (with-current-buffer "*vui-st*"
+                (goto-char (point-min))
+                (expect (how-many "^note: footer$") :to-equal 1)
+                (goto-char (point-max))
+                (expect (char-before) :to-equal ?r)))  ; ...footer
+          (vui-st--kill)))))
+
+  (it "is a no-op on an empty stream"
+    (let ((vui-render-delay nil)
+          (s (vui-make-stream)))
+      (let ((inst (vui-st--mount s "x")))
+        (ignore inst)
+        (unwind-protect
+            (progn
+              (vui-stream-update-last s (vui-text "ignored"))
+              (expect (vui-st--buffer) :to-equal (vui-st--oracle '() "x")))
+          (vui-st--kill))))))
+
 (provide 'vui-stream-test)
 ;;; vui-stream-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -3904,6 +3904,7 @@ bound when the stream is first rendered, and are nil until then."
   buffer
   region-start
   region-end
+  last-start        ; Marker at the start of the last item (for update-last)
   (items-rev nil)
   (separator "\n"))
 
@@ -3944,17 +3945,28 @@ repositions END explicitly instead."
     (setf (vui-stream-handle-region-start handle) s
           (vui-stream-handle-region-end handle) e)))
 
+(defun vui--stream-set-last-start (handle pos buffer)
+  "Record POS in BUFFER as the start of HANDLE's last item."
+  (let ((m (or (vui-stream-handle-last-start handle) (make-marker))))
+    (set-marker m pos buffer)
+    (set-marker-insertion-type m nil)
+    (setf (vui-stream-handle-last-start handle) m)))
+
 (defun vui--stream-render (handle)
   "Render HANDLE's items at point and bind its region around them.
 Used by the `vui-vnode-stream' branch of `vui--render-vnode'."
   (let ((sep (vui-stream-handle-separator handle))
         (start (point))
-        (first t))
+        (first t)
+        (last-start nil))
     (dolist (item (reverse (vui-stream-handle-items-rev handle)))
       (unless first (insert sep))
       (setq first nil)
+      (setq last-start (point))
       (vui--render-vnode item))
-    (vui--stream-bind-region handle (current-buffer) start (point))))
+    (vui--stream-bind-region handle (current-buffer) start (point))
+    (when last-start
+      (vui--stream-set-last-start handle last-start (current-buffer)))))
 
 (defun vui--stream-request-rerender (handle)
   "Re-render the root of HANDLE's buffer so the layout reflects new items."
@@ -4001,10 +4013,36 @@ supported yet."
             (goto-char (marker-position end))
             ;; There is already at least one item, so separate from it.
             (insert (vui-stream-handle-separator handle))
+            (vui--stream-set-last-start handle (point) buf)
             (vui--render-vnode vnode)
             ;; END stays put on insert (so the parent's separator below is
             ;; never captured); move it explicitly past what we inserted.
             (set-marker end (point))))))))
+  handle)
+
+(defun vui-stream-update-last (handle vnode)
+  "Replace HANDLE's last item with VNODE, re-rendering only its region.
+This is the in-progress message in a streaming agent UI: as tokens
+arrive, update the last item with the message-so-far.  The cost depends
+on that one item's size, not on the number of items above it, so the
+transcript can be arbitrarily long.  A no-op when the stream is empty or
+not yet live.  VNODE must be a content vnode (text/fragment)."
+  (when (vui-stream-handle-items-rev handle)
+    (setcar (vui-stream-handle-items-rev handle) vnode)
+    (let ((buf (vui-stream-handle-buffer handle))
+          (ls (vui-stream-handle-last-start handle))
+          (end (vui-stream-handle-region-end handle)))
+      (when (and buf (buffer-live-p buf)
+                 ls (marker-position ls) end (marker-position end))
+        (with-current-buffer buf
+          (let ((inhibit-read-only t)
+                (inhibit-modification-hooks t)
+                (buffer-undo-list t))
+            (save-excursion
+              (delete-region (marker-position ls) (marker-position end))
+              (goto-char (marker-position ls))
+              (vui--render-vnode vnode)
+              (set-marker end (point))))))))
   handle)
 
 (defun vui--render-vnode (vnode)

--- a/vui.el
+++ b/vui.el
@@ -662,6 +662,14 @@ parsing and validation, use `vui-typed-field' from vui-components.el."
   on-error          ; Optional (lambda (error)) callback when error caught
   id)               ; Unique identifier for this boundary (for state tracking)
 
+;; Stream vnode - anchors an append-only region (see "Streaming" below)
+(cl-defstruct (vui-vnode-stream (:include vui-vnode)
+                                (:constructor vui-vnode-stream--create))
+  "Virtual node that anchors a `vui-stream' handle's managed region.
+The handle owns the region's markers and item list; rendering this
+vnode (re-)emits the items and binds the region around them."
+  handle)           ; The vui-stream-handle this node anchors
+
 ;; Error boundary state lives on the root instance of a mounted tree
 ;; (see `vui-instance-boundary-errors').  This buffer-local table is
 ;; the fallback for static `vui-render' trees, which have no instance.
@@ -3870,6 +3878,135 @@ function of the root `vui--render-instance' call."
       (setf (vui-instance-render-record instance)
             (list :kind 'wholesale :vnode vtree))))))
 
+;;; Streaming - imperative append-only regions (issue #82)
+;;
+;; A `vui-stream' is an escape hatch from "re-render the whole tree from
+;; state" for the one shape where that is fundamentally too expensive: an
+;; append-only log that grows without bound (a chat transcript, a build
+;; log).  The declarative path rebuilds all N items on every append, so a
+;; stream of N is O(N^2); a stream owns its buffer region and appends ONE
+;; item in O(1), never touching the existing N.
+;;
+;; The handle (a `vui-stream-handle') holds the region markers and the
+;; item list.  Place it in the render tree with `(vui-stream handle)' so
+;; it gets a region and participates in layout; drive it imperatively
+;; with `(vui-stream-append handle vnode)'.  The item list is the source
+;; of truth: append writes one region in O(1) when the stream is live,
+;; and a full re-render (e.g. a sibling's state change) re-emits the list
+;; so the buffer stays identical to what a plain list would render.
+
+(cl-defstruct (vui-stream-handle (:constructor vui--stream-handle-create)
+                                 (:copier nil))
+  "State for a `vui-stream': its buffer region and items.
+ITEMS-REV holds the appended vnodes in REVERSE order, so append is O(1)
+\(a `push'); render reverses once.  BUFFER and the REGION-* markers are
+bound when the stream is first rendered, and are nil until then."
+  buffer
+  region-start
+  region-end
+  (items-rev nil)
+  (separator "\n"))
+
+(defun vui-make-stream (&optional separator)
+  "Create a `vui-stream-handle'.  SEPARATOR goes between items (default newline).
+Prefer `vui-use-stream' inside a component; use this directly only when
+you manage the handle's lifetime yourself."
+  (vui--stream-handle-create :separator (or separator "\n")))
+
+(defun vui-use-stream (&optional separator)
+  "Return a stable `vui-stream-handle' for the current component.
+Like the other hooks, call it unconditionally in render; the same handle
+is returned across re-renders.  Place it with `(vui-stream HANDLE)' and
+append to it with `(vui-stream-append HANDLE VNODE)'.  SEPARATOR (the
+string between items, default a newline) is used only on first creation."
+  (let ((ref (vui--get-or-create-ref nil)))
+    (or (car ref)
+        (setcar ref (vui-make-stream separator)))))
+
+(defun vui-stream (handle &rest props)
+  "Create a stream vnode that anchors HANDLE's region in the render tree.
+PROPS may carry :key for reconciliation."
+  (vui-vnode-stream--create :handle handle :key (plist-get props :key)))
+
+(defun vui--stream-bind-region (handle buffer start end)
+  "Point HANDLE's markers at BUFFER region [START, END) after a render.
+START stays put (top boundary); END stays before text inserted at its
+position too, so the separator the parent container inserts right after
+the stream does not get pulled into the region - `vui-stream-append'
+repositions END explicitly instead."
+  (setf (vui-stream-handle-buffer handle) buffer)
+  (let ((s (or (vui-stream-handle-region-start handle) (make-marker)))
+        (e (or (vui-stream-handle-region-end handle) (make-marker))))
+    (set-marker s start buffer)
+    (set-marker e end buffer)
+    (set-marker-insertion-type s nil)
+    (set-marker-insertion-type e nil)
+    (setf (vui-stream-handle-region-start handle) s
+          (vui-stream-handle-region-end handle) e)))
+
+(defun vui--stream-render (handle)
+  "Render HANDLE's items at point and bind its region around them.
+Used by the `vui-vnode-stream' branch of `vui--render-vnode'."
+  (let ((sep (vui-stream-handle-separator handle))
+        (start (point))
+        (first t))
+    (dolist (item (reverse (vui-stream-handle-items-rev handle)))
+      (unless first (insert sep))
+      (setq first nil)
+      (vui--render-vnode item))
+    (vui--stream-bind-region handle (current-buffer) start (point))))
+
+(defun vui--stream-request-rerender (handle)
+  "Re-render the root of HANDLE's buffer so the layout reflects new items."
+  (let ((buf (vui-stream-handle-buffer handle)))
+    (when (and buf (buffer-live-p buf))
+      (when-let* ((root (vui-get-instance buf)))
+        (vui-rerender root)))))
+
+(defun vui-stream-append (handle vnode)
+  "Append VNODE to HANDLE's stream and return HANDLE.
+When the stream is live and already non-empty, this writes exactly one
+region in O(1) - it never re-renders or walks the existing items - and
+content below the region shifts down with it.
+
+The one exception is the empty -> non-empty transition: a container that
+lays the stream out (a `vui-vstack', say) drops an empty child and the
+separator that would follow it, so the first item changes the surrounding
+layout.  That first append therefore triggers a single full re-render;
+every subsequent append is O(1).  When the stream is not yet live the
+item is just recorded and emitted on the next render.
+
+VNODE must be a content vnode (text/fragment); component items are not
+supported yet."
+  (push vnode (vui-stream-handle-items-rev handle))
+  (let ((buf (vui-stream-handle-buffer handle))
+        (start (vui-stream-handle-region-start handle))
+        (end (vui-stream-handle-region-end handle)))
+    (cond
+     ;; Not live yet: emitted on the next render.
+     ((not (and buf (buffer-live-p buf) end (marker-position end)))
+      nil)
+     ;; Empty -> non-empty: the surrounding separators change, so re-lay
+     ;; the whole tree once.  (Only the very first item pays this.)
+     ((= (marker-position start) (marker-position end))
+      (vui--stream-request-rerender handle))
+     ;; Live and non-empty: O(1) imperative insert at the region end.
+     (t
+      (with-current-buffer buf
+        (let ((inhibit-read-only t)
+              (inhibit-modification-hooks t)
+              ;; Stream text is ephemeral UI, not document history.
+              (buffer-undo-list t))
+          (save-excursion
+            (goto-char (marker-position end))
+            ;; There is already at least one item, so separate from it.
+            (insert (vui-stream-handle-separator handle))
+            (vui--render-vnode vnode)
+            ;; END stays put on insert (so the parent's separator below is
+            ;; never captured); move it explicitly past what we inserted.
+            (set-marker end (point))))))))
+  handle)
+
 (defun vui--render-vnode (vnode)
   "Render VNODE into the current buffer at point."
   (cond
@@ -4348,6 +4485,10 @@ function of the root `vui--render-instance' call."
             (vui--render-instance instance)
             (setf (vui-instance-r-len instance) (- (point) start)))
         (vui--render-instance instance))))
+
+   ;; Stream - (re-)emit the handle's items and bind its region
+   ((vui-vnode-stream-p vnode)
+    (vui--stream-render (vui-vnode-stream-handle vnode)))
 
    ;; Context provider - push context and render children
    ((vui-vnode-provider-p vnode)


### PR DESCRIPTION
This is dir 5 from the #82 brain-dump: the one shape the declarative "re-render from state" model can't do cheaply - an append-only log that grows without bound (a chat transcript, build output). Rebuilding all N items on every append is O(N) per append and O(N^2) to stream N, no matter how the buffer is patched. `vui-stream` is an escape hatch for exactly that shape.

## The idea

A handle owns a marker-bounded buffer region and an item list. Place it in the tree with `(vui-stream handle)` so it lays out like any other child, then drive it imperatively:

- `vui-use-stream` / `vui-make-stream` - get a handle
- `vui-stream-append handle vnode` - append one item, O(1)
- `vui-stream-update-last handle vnode` - rewrite the in-progress (last) item, for token-by-token growth

An append writes exactly one region and never walks the existing items; declarative content below shifts down via markers. A full re-render (some sibling's state changes) re-emits the item list, so the buffer stays **byte-identical** to what a plain list would render - that's the correctness anchor. The one wrinkle: a container drops an empty child and its separator, so the empty -> non-empty transition does a single re-render; every later append is O(1).

## The numbers (batch, box below the stream)

| operation | declarative | vui-stream |
|---|---|---|
| append at N=4000 | ~21 ms, rising (O(N)) | ~0.02 ms, flat |
| grow last item at N=4000 | rebuild, rising | ~0.015 ms, flat |

Both slopes are flat - independent of transcript size - vs linear for the declarative rebuild (~950x at N=4000, widening with size since it's asymptotic). That's the dir-5 pass/fail metric (the streaming-growth slope goes flat) met.

## What's here

- The primitive in `vui.el` (new `vui-vnode-stream` + the handle/append/update-last functions).
- `docs/examples/13-agent-chat.el`: the declarative baseline agent UI (transcript above a persistent box+field), a byte-identical `vui-stream` variant, and a demo that types each message out word by word.
- Tests: byte-identity to the declarative oracle for append-only, across a 100-item stream, after a full re-render, and for update-last; the line/box below staying correct; point preserved. 573 specs green with `vui-incremental-render` off and on.
- Benches: `vui-bench-stream-append-growth`, `vui-bench-stream-update-last-growth`, plus the declarative baselines they beat.

## Deliberately deferred (follow-ups)

- **Box-update independence**: a box-only change still re-emits the transcript (O(N), ~5ms at 4000). Making it flat needs a scoped-patch commit that skips the live stream regions - the dir-1 patcher. Worth it once the box updates frequently (a live counter/spinner) over a large transcript.
- **Stateful component rows**: items are content vnodes (any static styling/layout per row - the example draws user/agent/tool distinctly). Rows with their own state/lifecycle/widgets (collapsible tool cards, copy buttons) are a bigger, separate piece.

Items are content vnodes (text/fragment) for now.