### PR TITLE
feat: box-update independence for vui-stream (#82)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -29,6 +29,15 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   vs ~21ms and rising for the declarative rebuild (~950x at N=4000, the gap
   widening with size). Items are content vnodes (text/fragment, drawn
   however you like per item) for now (#82).
+- With =vui-incremental-render= on, a re-render driven by a sibling's state
+  change (the "box" below a stream - status, queue, an input field) no
+  longer re-emits the whole transcript. When the root is a flat container
+  whose first child is a live stream, the stream's region is left untouched
+  (appends keep it current) and only the content after it is re-rendered,
+  so a box update is O(box) instead of O(N): ~0.18ms flat regardless of
+  stream size, vs ~5.7ms and rising at N=4000 (32x). Anything else (content
+  before the stream, more than one stream, an indented or faced container)
+  falls back to a wholesale rebuild, which is byte-identical. (#82)
 - =:memo= keyword for =vui-defcomponent=: =:memo t= is a shorthand for the
   most common =:should-update= - skip the re-render while props are
   shallow-equal (=equal= on each value) and state is unchanged, like

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -562,6 +562,32 @@ size - only the last item's region is rewritten."
              handle (vui-text (format "growing message token %d here" k))))))
       (vui-bench--agent-teardown inst buf))))
 
+(defun vui-bench-stream-box-update-growth ()
+  "Cost of a box-only state change on the stream UI, flag off vs on.
+Off rebuilds the whole transcript (O(N)); on leaves the stream region
+untouched and re-renders only the box (the stream-tail patch), so the
+slope should be FLAT - a box update is independent of transcript size."
+  (vui-bench--header "Stream box update: toggle box state at stream size S")
+  (dolist (s '(200 500 1000 2000 4000))
+    (dolist (flag '((nil . "off") (t . "on")))
+      (let* ((vui-incremental-render (car flag))
+             (handle (vui-make-stream))
+             (buf "*vui-bench-stream-box*")
+             (inst (vui-mount (vui-component 'vui-agent-chat-stream
+                                             :stream handle :queue 0 :status "idle")
+                              buf))
+             (tog nil))
+        (dotimes (i s)
+          (vui-stream-append handle (vui-text (format "message %d" i))))
+        (vui-update inst (list :stream handle :queue 0 :status "idle"))
+        (vui-bench--result-row
+         (format "%d %s" s (cdr flag))
+         (vui-bench--measure
+          6 (lambda () (setq tog (not tog))
+              (vui-update inst (list :stream handle :queue (if tog 1 0)
+                                     :status (if tog "busy" "idle"))))))
+        (vui-bench--agent-teardown inst buf)))))
+
 (defun vui-bench-agent-run ()
   "Run the streaming-seam benchmarks (declarative baseline + vui-stream)."
   (interactive)
@@ -573,6 +599,7 @@ size - only the last item's region is rewritten."
     (vui-bench-agent-box-update)
     (vui-bench-stream-append-growth)
     (vui-bench-stream-update-last-growth)
+    (vui-bench-stream-box-update-growth)
     (message "")
     (message "done.")))
 
@@ -814,6 +841,7 @@ machine-readable CMPDATA lines."
     (vui-bench-agent-box-update)
     (vui-bench-stream-append-growth)
     (vui-bench-stream-update-last-growth)
+    (vui-bench-stream-box-update-growth)
     (message "")
     (message "done.")))
 

--- a/test/vui-stream-tail-test.el
+++ b/test/vui-stream-tail-test.el
@@ -1,0 +1,113 @@
+;;; vui-stream-tail-test.el --- Box-update independence for vui-stream -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; When a flat container's first child is a live `vui-stream', a re-render
+;; driven by a sibling's state change (the "box" below) should leave the
+;; stream's region untouched and re-render only the content after it -
+;; O(content), not O(N items).  Behind `vui-incremental-render'.
+;;
+;; The bar (Boris's protocol): PARITY - flag-on output must be byte-
+;; identical to the flag-off wholesale rebuild, across operation
+;; sequences and box shapes (a plain text line, and a real field widget);
+;; and MECHANISM - a box update must not erase the stream region (a marker
+;; placed inside it must survive), proving the patch ran rather than a
+;; silent wholesale fallback.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+;; Box as a plain text line (label is a prop, so a box update is a vui-update).
+(vui-defcomponent vui-stt-app (stream label)
+  :render (vui-vstack
+           (vui-stream stream)
+           (vui-text (format "box: %s" label))))
+
+;; Box as a component with a field widget, to exercise widget teardown.
+(vui-defcomponent vui-stt-box (label)
+  :state ((draft ""))
+  :render (vui-vstack
+           (vui-text (format "status: %s" label))
+           (vui-field :value draft :size 10
+                      :on-change (lambda (v) (vui-set-state :draft v)))))
+
+(vui-defcomponent vui-stt-app-field (stream label)
+  :render (vui-vstack
+           (vui-stream stream)
+           (vui-component 'vui-stt-box :label label)))
+
+;; Stream NOT first (a header above it): must fall back to wholesale, still correct.
+(vui-defcomponent vui-stt-app-header (stream label)
+  :render (vui-vstack
+           (vui-text "=== header ===")
+           (vui-stream stream)
+           (vui-text (format "box: %s" label))))
+
+(defun vui-stt--kill (buf)
+  (when (get-buffer buf)
+    (with-current-buffer buf
+      (let ((inhibit-modification-hooks t)) (kill-buffer buf)))))
+
+(defun vui-stt--scenario (component flag)
+  "Mount COMPONENT, append items and toggle the box label under FLAG.
+Return the final buffer string."
+  (let* ((vui-incremental-render flag)
+         (vui-render-delay nil)
+         (s (vui-make-stream))
+         (buf (format "*vui-stt-%s-%s*" component flag))
+         (inst (vui-mount (vui-component component :stream s :label "A") buf)))
+    (unwind-protect
+        (progn
+          (dotimes (i 20) (vui-stream-append s (vui-text (format "line %d" i))))
+          (vui-update inst (list :stream s :label "B"))   ; box update
+          (vui-update inst (list :stream s :label "C"))
+          (vui-stream-append s (vui-text "appended after box updates"))
+          (vui-stream-update-last s (vui-text "appended after box updates (grown)"))
+          (vui-update inst (list :stream s :label "D"))
+          (with-current-buffer buf (buffer-string)))
+      (vui-stt--kill buf))))
+
+(describe "vui-stream box-update: parity (flag on == flag off)"
+  (it "matches wholesale for a plain text box"
+    (expect (vui-stt--scenario 'vui-stt-app t)
+            :to-equal (vui-stt--scenario 'vui-stt-app nil)))
+
+  (it "matches wholesale for a field-widget box"
+    (expect (vui-stt--scenario 'vui-stt-app-field t)
+            :to-equal (vui-stt--scenario 'vui-stt-app-field nil)))
+
+  (it "matches wholesale when the stream is not first (wholesale fallback)"
+    (expect (vui-stt--scenario 'vui-stt-app-header t)
+            :to-equal (vui-stt--scenario 'vui-stt-app-header nil))))
+
+(describe "vui-stream box-update: mechanism (stream region left intact)"
+  (it "does not erase the stream region on a box update"
+    (let* ((vui-incremental-render t)
+           (vui-render-delay nil)
+           (s (vui-make-stream))
+           (buf "*vui-stt-mech*")
+           (inst (vui-mount (vui-component 'vui-stt-app :stream s :label "A") buf)))
+      (unwind-protect
+          (progn
+            (dotimes (i 20) (vui-stream-append s (vui-text (format "line %d" i))))
+            ;; warm up: the first box update marks the record as stream-tail
+            (vui-update inst (list :stream s :label "B"))
+            (with-current-buffer buf
+              (let* ((mid (copy-marker (/ (point-max) 2)))
+                     (char-at-mid (char-after mid))
+                     (pos-before (marker-position mid)))
+                ;; a box update must patch only the tail; a wholesale rebuild
+                ;; would erase the buffer and collapse this marker to 1
+                (vui-update inst (list :stream s :label "C"))
+                (expect (marker-position mid) :to-equal pos-before)
+                (expect (char-after mid) :to-equal char-at-mid)
+                ;; and it really did update the box
+                (expect (buffer-string) :to-match "box: C"))))
+        (vui-stt--kill buf)))))
+
+(provide 'vui-stream-tail-test)
+;;; vui-stream-tail-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -3824,6 +3824,17 @@ function of the root `vui--render-instance' call."
      ;; experimental `vui-incremental-render' flag.
      ((and record (eq vtree (plist-get record :vnode)))
       nil)
+     ;; Stream-tail patch: a flat container whose first child is a live
+     ;; stream.  The stream's region is already current (append /
+     ;; update-last keep the buffer in sync), so leave it untouched and
+     ;; re-render only the content after it - O(content), not O(N items).
+     ((and vui-incremental-render
+           (eq (plist-get record :kind) 'stream-tail)
+           (vui--stream-tail-eligible vtree))
+      (let ((elig (vui--stream-tail-eligible vtree)))
+        (vui--patch-stream-tail vtree (nth 0 elig) (nth 1 elig)))
+      (setf (vui-instance-render-record instance)
+            (list :kind 'stream-tail :vnode vtree)))
      ;; Content patch: flat content container, reuse unchanged segments.
      ((and vui-incremental-render
            (eq (plist-get record :kind) 'content)
@@ -3875,8 +3886,13 @@ function of the root `vui--render-instance' call."
       (vui--remove-widget-overlays)
       (erase-buffer)
       (vui--render-vnode vtree)
+      ;; If a stream just became live in this render, mark the record so
+      ;; the next commit can patch around it instead of re-emitting it.
       (setf (vui-instance-render-record instance)
-            (list :kind 'wholesale :vnode vtree))))))
+            (list :kind (if (and vui-incremental-render
+                                  (vui--stream-tail-eligible vtree))
+                            'stream-tail 'wholesale)
+                  :vnode vtree))))))
 
 ;;; Streaming - imperative append-only regions (issue #82)
 ;;
@@ -4044,6 +4060,78 @@ not yet live.  VNODE must be a content vnode (text/fragment)."
               (vui--render-vnode vnode)
               (set-marker end (point))))))))
   handle)
+
+;; --- Box-update independence: re-render around a live stream, not it ---
+;;
+;; A re-render driven by a sibling's state change (the "box" below the
+;; stream) would erase the whole buffer and re-emit every stream item,
+;; making that update O(N).  When the root is a flat container whose FIRST
+;; child is a live stream, the stream's region is already current (appends
+;; and update-last keep the buffer in sync), so we can leave it untouched
+;; and re-render only the content after it - O(content), independent of N.
+;; Anything else (a child before the stream, more than one stream, an
+;; indented/faced vstack) falls back to a wholesale rebuild, which is
+;; always correct.  Gated behind `vui-incremental-render'.
+
+(defun vui--stream-live-p (handle)
+  "Non-nil if HANDLE is a stream rendered live in the current buffer."
+  (and (vui-stream-handle-p handle)
+       (eq (vui-stream-handle-buffer handle) (current-buffer))
+       (let ((s (vui-stream-handle-region-start handle))
+             (e (vui-stream-handle-region-end handle)))
+         (and s (marker-position s) e (marker-position e)))))
+
+(defun vui--stream-tail-eligible (vtree)
+  "Return (HANDLE SUFFIX) when VTREE is a flat container whose first child
+is a live stream and no other child is a stream; else nil.  SUFFIX is the
+list of vnodes after the stream.  Only plain (indent 0, no face/keymap)
+vstacks and fragments qualify."
+  (let ((children
+         (cond ((vui-vnode-fragment-p vtree) (vui-vnode-fragment-children vtree))
+               ((and (vui-vnode-vstack-p vtree)
+                     (= 0 (or (vui-vnode-vstack-indent vtree) 0))
+                     (null (vui-vnode-vstack-face vtree))
+                     (null (vui-vnode-vstack-keymap vtree)))
+                (vui-vnode-vstack-children vtree))
+               (t :no))))
+    (when (listp children)
+      (let ((cs (remq nil children)))
+        (when (and cs
+                   (vui-vnode-stream-p (car cs))
+                   (vui--stream-live-p (vui-vnode-stream-handle (car cs)))
+                   (not (cl-some #'vui-vnode-stream-p (cdr cs))))
+          (list (vui-vnode-stream-handle (car cs)) (cdr cs)))))))
+
+(defun vui--render-children-as (vtree children)
+  "Render CHILDREN as a container shaped like VTREE; return chars written.
+Reuses the real renderer so inter-child separators, empty-drop, and
+component reconciliation all match a wholesale render exactly."
+  (let ((start (point)))
+    (vui--render-vnode
+     (if (vui-vnode-fragment-p vtree)
+         (vui-vnode-fragment--create :children children)
+       (vui-vnode-vstack--create
+        :children children
+        :spacing (vui-vnode-vstack-spacing vtree)
+        :indent 0)))
+    (- (point) start)))
+
+(defun vui--patch-stream-tail (vtree handle suffix)
+  "Re-render only the content after HANDLE's region, leaving the region.
+SUFFIX is the list of vnodes after the stream in VTREE.  The stream is
+non-empty (live), so the suffix is separated from it by one container
+separator, which we drop if the suffix renders to nothing (matching a
+wholesale render's empty-child handling)."
+  (let* ((sep (vui--incremental-separator vtree))
+         (from (marker-position (vui-stream-handle-region-end handle))))
+    (vui--forget-region-fields from (point-max))
+    (vui--remove-widget-overlays from (point-max))
+    (delete-region from (point-max))
+    (goto-char from)
+    (let ((p (point)))
+      (insert sep)
+      (when (= 0 (vui--render-children-as vtree suffix))
+        (delete-region p (point))))))
 
 (defun vui--render-vnode (vnode)
   "Render VNODE into the current buffer at point."


### PR DESCRIPTION
First of the two vui-stream follow-ups. Today, when something *around* a stream re-renders - the status line, a queue counter, the input field below the transcript - the whole buffer gets erased and every stream item re-emitted, so that update is O(N). Fine when N is small and the box rarely changes, but a live spinner or token counter over a 10k-line transcript would re-emit 10k items several times a second.

This makes a box update O(box) instead. With `vui-incremental-render` on, when the root is a flat container whose first child is a live stream, the commit leaves the stream's region alone (appends and update-last already keep it in sync with the buffer) and re-renders only the content after it.

The tricky part is staying byte-identical to a wholesale render. Rather than reimplement vstack's separator/empty-drop logic, the tail is rendered by the *real* renderer as a sub-container, so inter-child separators, empty children, and component reconciliation all match by construction; only the single stream->tail separator is handled by hand (dropped when the tail renders empty). Anything that doesn't fit the shape - content before the stream, more than one stream, an indented or faced container - falls back to a plain wholesale rebuild, which is always correct.

Numbers (batch, box below a stream):

| N | box update OFF | box update ON |
|---|----------------|---------------|
| 200 | 0.46 ms | 0.19 ms |
| 1000 | 1.49 ms | 0.18 ms |
| 4000 | 5.7 ms | 0.18 ms |

Off rises linearly; on is flat - independent of transcript size (32x at N=4000).

`test/vui-stream-tail-test.el` holds the bar: PARITY (flag-on output byte-identical to the flag-off wholesale rebuild, across a text box, a field-widget box, and the stream-not-first fallback) and MECHANISM (a marker placed inside the stream region survives a box update, proving the stream was left intact rather than silently rebuilt). 577 specs green with the flag off and on.

Gated behind `vui-incremental-render` (still off by default), consistent with the other experimental incremental paths. Next vui-stream follow-up: stateful component rows.