### PR TITLE
feat: box-update independence default-on (#82)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -29,15 +29,17 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   vs ~21ms and rising for the declarative rebuild (~950x at N=4000, the gap
   widening with size). Items are content vnodes (text/fragment, drawn
   however you like per item) for now (#82).
-- With =vui-incremental-render= on, a re-render driven by a sibling's state
-  change (the "box" below a stream - status, queue, an input field) no
-  longer re-emits the whole transcript. When the root is a flat container
-  whose first child is a live stream, the stream's region is left untouched
-  (appends keep it current) and only the content after it is re-rendered,
-  so a box update is O(box) instead of O(N): ~0.18ms flat regardless of
-  stream size, vs ~5.7ms and rising at N=4000 (32x). Anything else (content
-  before the stream, more than one stream, an indented or faced container)
-  falls back to a wholesale rebuild, which is byte-identical. (#82)
+- A re-render driven by a sibling's state change (the "box" below a stream
+  - status, queue, an input field) no longer re-emits the whole transcript.
+  When the root is a flat container whose first child is a live stream, the
+  stream's region is left untouched (appends keep it current) and only the
+  content after it is re-rendered, so a box update is O(box) instead of
+  O(N): ~0.18ms flat regardless of stream size, vs ~5.7ms and rising at
+  N=4000 (32x). Anything else (content before the stream, more than one
+  stream, an indented or faced container) falls back to a wholesale
+  rebuild. This is always on (like the whole-tree skip, it only ever
+  reproduces what a wholesale rebuild would, byte-identical), independent
+  of the experimental =vui-incremental-render= flag. (#82)
 - =:memo= keyword for =vui-defcomponent=: =:memo t= is a shorthand for the
   most common =:should-update= - skip the re-render while props are
   shallow-equal (=equal= on each value) and state is unchanged, like

--- a/test/vui-stream-tail-test.el
+++ b/test/vui-stream-tail-test.el
@@ -5,97 +5,124 @@
 ;;; Commentary:
 
 ;; When a flat container's first child is a live `vui-stream', a re-render
-;; driven by a sibling's state change (the "box" below) should leave the
-;; stream's region untouched and re-render only the content after it -
-;; O(content), not O(N items).  Behind `vui-incremental-render'.
+;; driven by a sibling's state change (the "box" below) leaves the stream's
+;; region untouched and re-renders only the content after it - O(content),
+;; not O(N items).  This is always on (it only ever reproduces what a
+;; wholesale rebuild would).
 ;;
-;; The bar (Boris's protocol): PARITY - flag-on output must be byte-
-;; identical to the flag-off wholesale rebuild, across operation
-;; sequences and box shapes (a plain text line, and a real field widget);
-;; and MECHANISM - a box update must not erase the stream region (a marker
+;; The bar (Boris's protocol): PARITY - the stream-built UI (appends, box
+;; updates, update-last) must be byte-identical to a fresh DECLARATIVE
+;; render of the same final state (a true wholesale reference); and
+;; MECHANISM - a box update must not erase the stream region (a marker
 ;; placed inside it must survive), proving the patch ran rather than a
-;; silent wholesale fallback.
+;; wholesale rebuild.
 
 ;;; Code:
 
 (require 'buttercup)
 (require 'vui)
+(require 'cl-lib)
 
-;; Box as a plain text line (label is a prop, so a box update is a vui-update).
+;;; Stream-driven UIs (stream as the first child of a flat container)
+
 (vui-defcomponent vui-stt-app (stream label)
-  :render (vui-vstack
-           (vui-stream stream)
-           (vui-text (format "box: %s" label))))
+  :render (vui-vstack (vui-stream stream)
+                      (vui-text (format "box: %s" label))))
 
-;; Box as a component with a field widget, to exercise widget teardown.
 (vui-defcomponent vui-stt-box (label)
   :state ((draft ""))
-  :render (vui-vstack
-           (vui-text (format "status: %s" label))
-           (vui-field :value draft :size 10
-                      :on-change (lambda (v) (vui-set-state :draft v)))))
+  :render (vui-vstack (vui-text (format "status: %s" label))
+                      (vui-field :value draft :size 10
+                                 :on-change (lambda (v) (vui-set-state :draft v)))))
 
 (vui-defcomponent vui-stt-app-field (stream label)
-  :render (vui-vstack
-           (vui-stream stream)
-           (vui-component 'vui-stt-box :label label)))
+  :render (vui-vstack (vui-stream stream)
+                      (vui-component 'vui-stt-box :label label)))
 
-;; Stream NOT first (a header above it): must fall back to wholesale, still correct.
+;; Stream NOT first (a header above it): not eligible, falls back to wholesale.
 (vui-defcomponent vui-stt-app-header (stream label)
-  :render (vui-vstack
-           (vui-text "=== header ===")
-           (vui-stream stream)
-           (vui-text (format "box: %s" label))))
+  :render (vui-vstack (vui-text "=== header ===")
+                      (vui-stream stream)
+                      (vui-text (format "box: %s" label))))
+
+;;; Declarative equivalents (no stream) - the wholesale oracle
+
+(vui-defcomponent vui-stt-decl (lines label)
+  :render (vui-vstack (apply #'vui-vstack (mapcar #'vui-text lines))
+                      (vui-text (format "box: %s" label))))
+
+(vui-defcomponent vui-stt-decl-field (lines label)
+  :render (vui-vstack (apply #'vui-vstack (mapcar #'vui-text lines))
+                      (vui-component 'vui-stt-box :label label)))
+
+(vui-defcomponent vui-stt-decl-header (lines label)
+  :render (vui-vstack (vui-text "=== header ===")
+                      (apply #'vui-vstack (mapcar #'vui-text lines))
+                      (vui-text (format "box: %s" label))))
 
 (defun vui-stt--kill (buf)
   (when (get-buffer buf)
     (with-current-buffer buf
       (let ((inhibit-modification-hooks t)) (kill-buffer buf)))))
 
-(defun vui-stt--scenario (component flag)
-  "Mount COMPONENT, append items and toggle the box label under FLAG.
-Return the final buffer string."
-  (let* ((vui-incremental-render flag)
-         (vui-render-delay nil)
+(defun vui-stt--final-lines ()
+  "The line list the scenario below ends with."
+  (append (cl-loop for i below 20 collect (format "line %d" i))
+          (list "tail grown")))
+
+(defun vui-stt--stream-build (component)
+  "Mount stream COMPONENT, append lines, toggle the box, return the buffer.
+The box label ends at \"D\" and the stream ends with the lines from
+`vui-stt--final-lines'."
+  (let* ((vui-render-delay nil)
          (s (vui-make-stream))
-         (buf (format "*vui-stt-%s-%s*" component flag))
+         (buf "*vui-stt*")
          (inst (vui-mount (vui-component component :stream s :label "A") buf)))
     (unwind-protect
         (progn
           (dotimes (i 20) (vui-stream-append s (vui-text (format "line %d" i))))
           (vui-update inst (list :stream s :label "B"))   ; box update
           (vui-update inst (list :stream s :label "C"))
-          (vui-stream-append s (vui-text "appended after box updates"))
-          (vui-stream-update-last s (vui-text "appended after box updates (grown)"))
+          (vui-stream-append s (vui-text "tail"))
+          (vui-stream-update-last s (vui-text "tail grown"))
           (vui-update inst (list :stream s :label "D"))
           (with-current-buffer buf (buffer-string)))
       (vui-stt--kill buf))))
 
-(describe "vui-stream box-update: parity (flag on == flag off)"
-  (it "matches wholesale for a plain text box"
-    (expect (vui-stt--scenario 'vui-stt-app t)
-            :to-equal (vui-stt--scenario 'vui-stt-app nil)))
+(defun vui-stt--decl-oracle (component label)
+  "Buffer of a fresh declarative mount of COMPONENT with the final state."
+  (let* ((vui-render-delay nil)
+         (buf "*vui-stt-oracle*")
+         (inst (vui-mount (vui-component component
+                            :lines (vui-stt--final-lines) :label label)
+                          buf)))
+    (ignore inst)
+    (prog1 (with-current-buffer buf (buffer-string))
+      (vui-stt--kill buf))))
 
-  (it "matches wholesale for a field-widget box"
-    (expect (vui-stt--scenario 'vui-stt-app-field t)
-            :to-equal (vui-stt--scenario 'vui-stt-app-field nil)))
+(describe "vui-stream box-update: parity with a wholesale declarative render"
+  (it "matches for a plain text box"
+    (expect (vui-stt--stream-build 'vui-stt-app)
+            :to-equal (vui-stt--decl-oracle 'vui-stt-decl "D")))
 
-  (it "matches wholesale when the stream is not first (wholesale fallback)"
-    (expect (vui-stt--scenario 'vui-stt-app-header t)
-            :to-equal (vui-stt--scenario 'vui-stt-app-header nil))))
+  (it "matches for a field-widget box"
+    (expect (vui-stt--stream-build 'vui-stt-app-field)
+            :to-equal (vui-stt--decl-oracle 'vui-stt-decl-field "D")))
+
+  (it "matches when the stream is not first (wholesale fallback)"
+    (expect (vui-stt--stream-build 'vui-stt-app-header)
+            :to-equal (vui-stt--decl-oracle 'vui-stt-decl-header "D"))))
 
 (describe "vui-stream box-update: mechanism (stream region left intact)"
   (it "does not erase the stream region on a box update"
-    (let* ((vui-incremental-render t)
-           (vui-render-delay nil)
+    (let* ((vui-render-delay nil)
            (s (vui-make-stream))
            (buf "*vui-stt-mech*")
            (inst (vui-mount (vui-component 'vui-stt-app :stream s :label "A") buf)))
       (unwind-protect
           (progn
             (dotimes (i 20) (vui-stream-append s (vui-text (format "line %d" i))))
-            ;; warm up: the first box update marks the record as stream-tail
-            (vui-update inst (list :stream s :label "B"))
+            (vui-update inst (list :stream s :label "B"))   ; record -> stream-tail
             (with-current-buffer buf
               (let* ((mid (copy-marker (/ (point-max) 2)))
                      (char-at-mid (char-after mid))
@@ -105,7 +132,6 @@ Return the final buffer string."
                 (vui-update inst (list :stream s :label "C"))
                 (expect (marker-position mid) :to-equal pos-before)
                 (expect (char-after mid) :to-equal char-at-mid)
-                ;; and it really did update the box
                 (expect (buffer-string) :to-match "box: C"))))
         (vui-stt--kill buf)))))
 

--- a/vui.el
+++ b/vui.el
@@ -3828,8 +3828,11 @@ function of the root `vui--render-instance' call."
      ;; stream.  The stream's region is already current (append /
      ;; update-last keep the buffer in sync), so leave it untouched and
      ;; re-render only the content after it - O(content), not O(N items).
-     ((and vui-incremental-render
-           (eq (plist-get record :kind) 'stream-tail)
+     ;; Always on: it only ever reproduces what a wholesale rebuild would
+     ;; (byte-identical), and falls back below for any other shape, so it
+     ;; needs no opt-in - and stateful stream rows depend on it leaving the
+     ;; region intact regardless of the experimental flag.
+     ((and (eq (plist-get record :kind) 'stream-tail)
            (vui--stream-tail-eligible vtree))
       (let ((elig (vui--stream-tail-eligible vtree)))
         (vui--patch-stream-tail vtree (nth 0 elig) (nth 1 elig)))
@@ -3889,8 +3892,7 @@ function of the root `vui--render-instance' call."
       ;; If a stream just became live in this render, mark the record so
       ;; the next commit can patch around it instead of re-emitting it.
       (setf (vui-instance-render-record instance)
-            (list :kind (if (and vui-incremental-render
-                                  (vui--stream-tail-eligible vtree))
+            (list :kind (if (vui--stream-tail-eligible vtree)
                             'stream-tail 'wholesale)
                   :vnode vtree))))))
 


### PR DESCRIPTION
Small follow-up: promote the stream-tail patch from PR #92 (box-update independence) to default-on, off the experimental `vui-incremental-render` flag.

The reasoning is the same as the whole-tree eq-skip: the stream-tail patch only ever reproduces what a wholesale rebuild would (byte-identical), and falls back to a wholesale rebuild for any shape it doesn't recognise, so it carries no risk and needs no opt-in. Un-gated, the agent-UI shape (a transcript stream above a status/queue/input box) gets flat O(box) updates by default instead of re-emitting the whole transcript - no flag to flip.

It's also the prerequisite for the next vui-stream piece (stateful component rows): those rows are inline instances living inside the stream's region, and they only survive a sibling re-render because the stream-tail patch leaves the region intact - which has to be true regardless of the flag.

The parity tests now compare the stream-built UI (appends + box updates + update-last) against a fresh *declarative* render of the same final state (a true wholesale reference), which is a stronger check than the previous flag-on vs flag-off. Plus the mechanism check (a marker inside the stream region survives a box update). 577 specs green with the flag off and on.