### PR TITLE
feat: stateful component rows in vui-stream (#82)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -29,6 +29,18 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   vs ~21ms and rising for the declarative rebuild (~950x at N=4000, the gap
   widening with size). Items are content vnodes (text/fragment, drawn
   however you like per item) for now (#82).
+- A =vui-stream= item may be a =vui-component=, mounted as a stateful ROW:
+  it gets its own region and re-renders only that region when its state
+  changes - a collapsible tool card, a copy button - independent of how
+  many items are above it (~0.15ms whether 200 or 4000 items precede it).
+  =vui-stream-append= mounts a component vnode inline at the tail (its
+  region-end is shared as the stream's, so the row growing on its own
+  re-render keeps the box below correct); =vui-stream-update-last= on a row
+  updates its props in place, preserving the row's state. Content and rows
+  interleave. A row needs the stream live and non-empty first (a component
+  appended to an empty stream falls back to a plain child render), and
+  relies on the always-on stream-tail patch to survive box updates; rows
+  unmount with the buffer (#82).
 - A re-render driven by a sibling's state change (the "box" below a stream
   - status, queue, an input field) no longer re-emits the whole transcript.
   When the root is a flat container whose first child is a live stream, the

--- a/benchmarks/vui-bench.el
+++ b/benchmarks/vui-bench.el
@@ -588,6 +588,37 @@ slope should be FLAT - a box update is independent of transcript size."
                                      :status (if tog "busy" "idle"))))))
         (vui-bench--agent-teardown inst buf)))))
 
+(vui-defcomponent vui-bench-stream-row (id)
+  :state ((open nil))
+  :render (vui-vstack
+           (vui-button (format "row %d %s" id (if open "v" ">"))
+             :on-click (lambda () (vui-set-state :open (not open))))
+           (when open (vui-text (format "detail for row %d, a few words here" id)))))
+
+(defun vui-bench-stream-row-rerender-growth ()
+  "Cost of toggling ONE stateful component row vs the items above it.
+A row is an inline instance, so its state change re-renders only its own
+region - this should be FLAT, independent of stream size, unlike walking
+or rebuilding the transcript."
+  (vui-bench--header "Stream row re-render: toggle 1 row at stream size S (box below)")
+  (dolist (s '(200 500 1000 2000 4000))
+    (let* ((handle (vui-make-stream))
+           (buf "*vui-bench-stream-row*")
+           (inst (vui-mount (vui-component 'vui-bench-stream-app :stream handle) buf)))
+      (dotimes (i s)
+        (vui-stream-append handle (vui-text (format "message %d content" i))))
+      (vui-stream-append handle (vui-component 'vui-bench-stream-row :id 9999))
+      (vui-bench--result-row
+       (format "%d row" s)
+       (vui-bench--measure
+        8 (lambda ()
+            (with-current-buffer buf
+              (goto-char (point-min))
+              (when (search-forward "row 9999" nil t)
+                (let ((w (widget-at (match-beginning 0))))
+                  (when w (widget-apply w :action))))))))
+      (vui-bench--agent-teardown inst buf))))
+
 (defun vui-bench-agent-run ()
   "Run the streaming-seam benchmarks (declarative baseline + vui-stream)."
   (interactive)
@@ -600,6 +631,7 @@ slope should be FLAT - a box update is independent of transcript size."
     (vui-bench-stream-append-growth)
     (vui-bench-stream-update-last-growth)
     (vui-bench-stream-box-update-growth)
+    (vui-bench-stream-row-rerender-growth)
     (message "")
     (message "done.")))
 
@@ -842,6 +874,7 @@ machine-readable CMPDATA lines."
     (vui-bench-stream-append-growth)
     (vui-bench-stream-update-last-growth)
     (vui-bench-stream-box-update-growth)
+    (vui-bench-stream-row-rerender-growth)
     (message "")
     (message "done.")))
 

--- a/docs/examples/13-agent-chat.el
+++ b/docs/examples/13-agent-chat.el
@@ -51,6 +51,19 @@ transcript, so a message renders identically whichever path emits it."
   "One transcript message, rendered differently depending on ROLE."
   :render (vui-chat-message-vnode role text))
 
+(vui-defcomponent vui-chat-tool-card (name output)
+  "A collapsible tool-call card: the header toggles the output.
+Appended as a stateful stream ROW - clicking it re-renders only this
+card's region, no matter how long the transcript is."
+  :state ((open nil))
+  :render
+  (vui-vstack
+   (vui-button (format "  [tool] %s  %s" name (if open "(hide)" "(show)"))
+     :face 'shadow
+     :on-click (lambda () (vui-set-state :open (not open))))
+   (when open
+     (vui-text (format "      -> %s" output) :face 'shadow))))
+
 ;;; Transcript - the O(n) part vui-stream will replace
 
 (vui-defcomponent vui-chat-transcript (messages)
@@ -171,18 +184,27 @@ INTERVAL defaults to 0.25."
                    (let* ((msg (nth mi script))
                           (role (car msg))
                           (words (split-string (cdr msg) " ")))
-                     (if (= wi 0)
-                         ;; first word: append a new message
-                         (vui-stream-append
-                          stream (vui-chat-message-vnode role (car words)))
-                       ;; later words: grow the in-progress message in place
+                     (cond
+                      ;; A tool call lands as a collapsible component ROW
+                      ;; (one tick); click it later to expand its output.
+                      ((eq role 'tool)
+                       (vui-stream-append
+                        stream (vui-component 'vui-chat-tool-card
+                                 :name (cdr msg) :output "ok - exit 0"))
+                       (setq mi (1+ mi) wi 0))
+                      ;; Text messages type out word by word, in place.
+                      ((= wi 0)
+                       (vui-stream-append
+                        stream (vui-chat-message-vnode role (car words)))
+                       (setq wi (1+ wi))
+                       (when (>= wi (length words)) (setq mi (1+ mi) wi 0)))
+                      (t
                        (vui-stream-update-last
                         stream
                         (vui-chat-message-vnode
-                         role (string-join (cl-subseq words 0 (1+ wi)) " "))))
-                     (setq wi (1+ wi))
-                     (when (>= wi (length words))
-                       (setq mi (1+ mi) wi 0))))))))
+                         role (string-join (cl-subseq words 0 (1+ wi)) " ")))
+                       (setq wi (1+ wi))
+                       (when (>= wi (length words)) (setq mi (1+ mi) wi 0))))))))))
           (lambda () (cancel-timer timer)))))
     (vui-component 'vui-agent-chat-stream
       :stream stream :queue queue :status status)))

--- a/test/vui-stream-rows-test.el
+++ b/test/vui-stream-rows-test.el
@@ -1,0 +1,168 @@
+;;; vui-stream-rows-test.el --- Stateful component rows in a vui-stream -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; A `vui-stream' item may be a `vui-component', mounted as a STATEFUL ROW:
+;; it has its own region and re-renders only that region when its state
+;; changes (a collapsible tool card, say), independent of the number of
+;; items above it.  These tests prove:
+;;   PARITY  - a stream of rows renders identically to the same components
+;;             rendered declaratively as children, including after state
+;;             changes (expand / collapse);
+;;   COEXIST - expanding the last row keeps the box below correct (the
+;;             stream's region-end follows the row's growth), and content
+;;             appended after rows lands correctly;
+;;   SCOPED  - expanding a row leaves the box region untouched (the row
+;;             re-renders only itself).
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+;; A collapsible row: the button toggles an extra detail line.
+(vui-defcomponent vui-sr-row (id)
+  :state ((open nil))
+  :render
+  (vui-vstack
+   (vui-button (format "[%s] row %s" (if open "v" ">") id)
+     :on-click (lambda () (vui-set-state :open (not open))))
+   (when open
+     (vui-text (format "   detail line for %s" id)))))
+
+;; Stream UI: rows live in the stream, a box sits below.
+(vui-defcomponent vui-sr-app (stream)
+  :render (vui-vstack (vui-stream stream)
+                      (vui-text "==== box (idle) ====")))
+
+;; Declarative equivalent: the same components as plain vstack children.
+(vui-defcomponent vui-sr-decl ()
+  :render (vui-vstack
+           (vui-text "system: started")
+           (vui-component 'vui-sr-row :key "A" :id "A")
+           (vui-component 'vui-sr-row :key "B" :id "B")
+           (vui-text "system: more")
+           (vui-text "==== box (idle) ====")))
+
+(defun vui-sr--kill (buf)
+  (when (get-buffer buf)
+    (with-current-buffer buf
+      (let ((inhibit-modification-hooks t)) (kill-buffer buf)))))
+
+(defun vui-sr--click (buf label)
+  "Invoke the button whose text contains LABEL in BUF."
+  (with-current-buffer buf
+    (goto-char (point-min))
+    (when (search-forward label nil t)
+      (let ((w (widget-at (match-beginning 0))))
+        (when w (widget-apply w :action))))))
+
+(defun vui-sr--build-stream (&rest clicks)
+  "Build the stream UI (content + 2 rows + content), apply CLICKS, return buffer."
+  (let* ((vui-render-delay nil) (s (vui-make-stream)) (buf "*vui-sr-s*")
+         (inst (vui-mount (vui-component 'vui-sr-app :stream s) buf)))
+    (ignore inst)
+    (unwind-protect
+        (progn
+          (vui-stream-append s (vui-text "system: started"))
+          (vui-stream-append s (vui-component 'vui-sr-row :id "A"))
+          (vui-stream-append s (vui-component 'vui-sr-row :id "B"))
+          (vui-stream-append s (vui-text "system: more"))
+          (dolist (c clicks) (vui-sr--click buf c))
+          (with-current-buffer buf (buffer-string)))
+      (vui-sr--kill buf))))
+
+(defun vui-sr--build-decl (&rest clicks)
+  "Build the declarative UI, apply CLICKS, return buffer."
+  (let* ((vui-render-delay nil) (buf "*vui-sr-d*")
+         (inst (vui-mount (vui-component 'vui-sr-decl) buf)))
+    (ignore inst)
+    (unwind-protect
+        (progn
+          (dolist (c clicks) (vui-sr--click buf c))
+          (with-current-buffer buf (buffer-string)))
+      (vui-sr--kill buf))))
+
+(describe "vui-stream rows: parity with declarative children"
+  (it "renders identically with all rows collapsed"
+    (expect (vui-sr--build-stream) :to-equal (vui-sr--build-decl)))
+
+  (it "renders identically after expanding both rows"
+    (expect (vui-sr--build-stream "row A" "row B")
+            :to-equal (vui-sr--build-decl "row A" "row B")))
+
+  (it "renders identically after expanding only the last row"
+    (expect (vui-sr--build-stream "row B")
+            :to-equal (vui-sr--build-decl "row B")))
+
+  (it "renders identically after expand-then-collapse (round trip)"
+    (expect (vui-sr--build-stream "row A" "row A")
+            :to-equal (vui-sr--build-decl))))
+
+(describe "vui-stream rows: coexistence with the box below"
+  (it "keeps the box correct and last after expanding the last row"
+    (let* ((vui-render-delay nil) (s (vui-make-stream)) (buf "*vui-sr-co*")
+           (inst (vui-mount (vui-component 'vui-sr-app :stream s) buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (vui-stream-append s (vui-text "system: started"))
+            (vui-stream-append s (vui-component 'vui-sr-row :id "A"))
+            (vui-sr--click buf "row A")     ; expand the last (only) row
+            (with-current-buffer buf
+              ;; region-end matches the live end of stream content (just
+              ;; before the box separator), and the box is still last
+              (expect (string-suffix-p "==== box (idle) ====" (buffer-string))
+                      :to-be t)
+              (expect (buffer-string) :to-match "detail line for A")))
+        (vui-sr--kill buf)))))
+
+(describe "vui-stream rows: re-render is scoped to the row"
+  (it "leaves the box region untouched when a row expands"
+    (let* ((vui-render-delay nil) (s (vui-make-stream)) (buf "*vui-sr-sc*")
+           (inst (vui-mount (vui-component 'vui-sr-app :stream s) buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (vui-stream-append s (vui-text "system: started"))
+            (vui-stream-append s (vui-component 'vui-sr-row :id "A"))
+            (with-current-buffer buf
+              ;; a marker inside the box; expanding the row must not erase
+              ;; or rewrite the box (only the row's region changes)
+              (goto-char (point-max))
+              (search-backward "box")
+              (let* ((m (copy-marker (point)))
+                     (ch (char-after m)))
+                (vui-sr--click buf "row A")
+                (expect (char-after m) :to-equal ch)
+                (expect (buffer-substring m (+ m 3)) :to-equal "box"))))
+        (vui-sr--kill buf)))))
+
+(describe "vui-stream rows: update-last refreshes a row's props in place"
+  (it "updates the row's props while keeping its state"
+    (let* ((vui-render-delay nil) (s (vui-make-stream)) (buf "*vui-sr-ul*")
+           (inst (vui-mount (vui-component 'vui-sr-app :stream s) buf)))
+      (ignore inst)
+      (unwind-protect
+          (progn
+            (vui-stream-append s (vui-text "system: started"))
+            (vui-stream-append s (vui-component 'vui-sr-row :id "Z"))
+            (vui-sr--click buf "row Z")          ; expand: state open = t
+            (with-current-buffer buf
+              (expect (buffer-string) :to-match "detail line for Z"))
+            ;; new data arrives for the in-progress row
+            (vui-stream-update-last s (vui-component 'vui-sr-row :id "Z2"))
+            (with-current-buffer buf
+              ;; props refreshed (Z -> Z2)...
+              (expect (buffer-string) :to-match "row Z2")
+              ;; ...and the row's expanded state survived the update
+              (expect (buffer-string) :to-match "detail line for Z2")
+              ;; box still correct and last
+              (expect (string-suffix-p "==== box (idle) ====" (buffer-string))
+                      :to-be t)))
+        (vui-sr--kill buf)))))
+
+(provide 'vui-stream-rows-test)
+;;; vui-stream-rows-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -3978,10 +3978,15 @@ Used by the `vui-vnode-stream' branch of `vui--render-vnode'."
         (first t)
         (last-start nil))
     (dolist (item (reverse (vui-stream-handle-items-rev handle)))
-      (unless first (insert sep))
-      (setq first nil)
-      (setq last-start (point))
-      (vui--render-vnode item))
+      ;; Component rows are inline instances that render and persist on
+      ;; their own; a full re-emit cannot reproduce them, and (because the
+      ;; stream-tail patch leaves the region intact) does not run once rows
+      ;; exist.  Skip them defensively here.
+      (unless (vui-instance-p item)
+        (unless first (insert sep))
+        (setq first nil)
+        (setq last-start (point))
+        (vui--render-vnode item)))
     (vui--stream-bind-region handle (current-buffer) start (point))
     (when last-start
       (vui--stream-set-last-start handle last-start (current-buffer)))))
@@ -3999,19 +4004,25 @@ When the stream is live and already non-empty, this writes exactly one
 region in O(1) - it never re-renders or walks the existing items - and
 content below the region shifts down with it.
 
-The one exception is the empty -> non-empty transition: a container that
-lays the stream out (a `vui-vstack', say) drops an empty child and the
-separator that would follow it, so the first item changes the surrounding
-layout.  That first append therefore triggers a single full re-render;
-every subsequent append is O(1).  When the stream is not yet live the
-item is just recorded and emitted on the next render.
+VNODE may be a content vnode (text/fragment) or a `vui-component'.  A
+component is mounted as a STATEFUL ROW: it gets its own region and
+re-renders only that region when its state changes (a collapsible tool
+card, say), independent of how many items are above it.  A component row
+requires the stream to be live and non-empty first (the empty -> non-empty
+transition does a full re-render, which cannot re-emit an inline row); a
+component appended to an empty stream falls back to a plain child render."
+  (if (vui-vnode-component-p vnode)
+      (vui--stream-append-row handle vnode)
+    (vui--stream-append-content handle vnode))
+  handle)
 
-VNODE must be a content vnode (text/fragment); component items are not
-supported yet."
-  (push vnode (vui-stream-handle-items-rev handle))
-  (let ((buf (vui-stream-handle-buffer handle))
+(defun vui--stream-append-content (handle vnode)
+  "Append content VNODE (text/fragment) to HANDLE's stream."
+  (let ((prev-last (car (vui-stream-handle-items-rev handle)))
+        (buf (vui-stream-handle-buffer handle))
         (start (vui-stream-handle-region-start handle))
         (end (vui-stream-handle-region-end handle)))
+    (push vnode (vui-stream-handle-items-rev handle))
     (cond
      ;; Not live yet: emitted on the next render.
      ((not (and buf (buffer-live-p buf) end (marker-position end)))
@@ -4029,38 +4040,95 @@ supported yet."
               (buffer-undo-list t))
           (save-excursion
             (goto-char (marker-position end))
-            ;; There is already at least one item, so separate from it.
             (insert (vui-stream-handle-separator handle))
             (vui--stream-set-last-start handle (point) buf)
             (vui--render-vnode vnode)
-            ;; END stays put on insert (so the parent's separator below is
-            ;; never captured); move it explicitly past what we inserted.
-            (set-marker end (point))))))))
-  handle)
+            ;; If the previous last item was a component row, END is that
+            ;; row's own marker - do NOT move it (that would corrupt the
+            ;; row's region); install a fresh marker.  Otherwise reuse the
+            ;; stream's own END marker.
+            (if (vui-instance-p prev-last)
+                (setf (vui-stream-handle-region-end handle)
+                      (copy-marker (point) nil))
+              (set-marker end (point))))))))))
+
+(defun vui--stream-append-row (handle vnode)
+  "Append component VNODE as a stateful inline row at HANDLE's tail."
+  (let ((buf (vui-stream-handle-buffer handle))
+        (start (vui-stream-handle-region-start handle))
+        (end (vui-stream-handle-region-end handle))
+        (sep (vui-stream-handle-separator handle)))
+    (cond
+     ;; Not live, or still empty: a row needs a live, non-empty stream.
+     ;; Record the vnode and lay it out with a full render (it renders as a
+     ;; plain child component, not a scoped row - the documented fallback).
+     ((or (not (and buf (buffer-live-p buf) end (marker-position end)))
+          (= (marker-position start) (marker-position end)))
+      (push vnode (vui-stream-handle-items-rev handle))
+      (when (and buf (buffer-live-p buf))
+        (vui--stream-request-rerender handle)))
+     (t
+      (with-current-buffer buf
+        (let ((inhibit-read-only t)
+              (inhibit-modification-hooks t)
+              (buffer-undo-list t))
+          (save-excursion
+            (goto-char (marker-position end))
+            (insert sep)
+            (let* ((row-start (point))
+                   (row (vui-mount-inline vnode (point))))
+              (vui--stream-set-last-start handle row-start buf)
+              ;; Share the row's region-end as the stream's end: when the
+              ;; row re-renders on its own (grows/shrinks), its marker moves
+              ;; and the stream end - and the box below - stay correct.
+              (setf (vui-stream-handle-region-end handle)
+                    (vui-instance-region-end row))
+              (push row (vui-stream-handle-items-rev handle))))))))))
 
 (defun vui-stream-update-last (handle vnode)
   "Replace HANDLE's last item with VNODE, re-rendering only its region.
 This is the in-progress message in a streaming agent UI: as tokens
 arrive, update the last item with the message-so-far.  The cost depends
-on that one item's size, not on the number of items above it, so the
-transcript can be arbitrarily long.  A no-op when the stream is empty or
-not yet live.  VNODE must be a content vnode (text/fragment)."
-  (when (vui-stream-handle-items-rev handle)
-    (setcar (vui-stream-handle-items-rev handle) vnode)
-    (let ((buf (vui-stream-handle-buffer handle))
-          (ls (vui-stream-handle-last-start handle))
-          (end (vui-stream-handle-region-end handle)))
-      (when (and buf (buffer-live-p buf)
-                 ls (marker-position ls) end (marker-position end))
-        (with-current-buffer buf
-          (let ((inhibit-read-only t)
-                (inhibit-modification-hooks t)
-                (buffer-undo-list t))
-            (save-excursion
-              (delete-region (marker-position ls) (marker-position end))
-              (goto-char (marker-position ls))
-              (vui--render-vnode vnode)
-              (set-marker end (point))))))))
+on that one item, not on the number of items above it, so the transcript
+can be arbitrarily long.  A no-op when the stream is empty or not live.
+
+For a content last item VNODE must be a content vnode (text/fragment).
+For a component ROW, pass a `vui-component' of the same type: the row's
+props are updated in place and the row re-renders only its own region,
+keeping its state."
+  (let ((last (car (vui-stream-handle-items-rev handle))))
+    (cond
+     ((null last) nil)
+     ;; Component row: update its props in place (state preserved); the row
+     ;; re-renders only its region and its END marker (shared as the
+     ;; stream's) follows.
+     ((vui-instance-p last)
+      (when (and (vui-vnode-component-p vnode)
+                 (eq (vui-vnode-component-type vnode)
+                     (vui-component-def-name (vui-instance-def last))))
+        (let* ((props (vui-vnode-component-props vnode))
+               (children (vui-vnode-component-children vnode))
+               (props-wc (if children
+                             (plist-put (copy-sequence props) :children children)
+                           props)))
+          (vui-update last props-wc))))
+     ;; Content: rewrite just that item's region.
+     (t
+      (setcar (vui-stream-handle-items-rev handle) vnode)
+      (let ((buf (vui-stream-handle-buffer handle))
+            (ls (vui-stream-handle-last-start handle))
+            (end (vui-stream-handle-region-end handle)))
+        (when (and buf (buffer-live-p buf)
+                   ls (marker-position ls) end (marker-position end))
+          (with-current-buffer buf
+            (let ((inhibit-read-only t)
+                  (inhibit-modification-hooks t)
+                  (buffer-undo-list t))
+              (save-excursion
+                (delete-region (marker-position ls) (marker-position end))
+                (goto-char (marker-position ls))
+                (vui--render-vnode vnode)
+                (set-marker end (point))))))))))
   handle)
 
 ;; --- Box-update independence: re-render around a live stream, not it ---


### PR DESCRIPTION
The last vui-stream piece. A stream item can now be a `vui-component`, mounted as a stateful **row**: it gets its own region and re-renders only that region when its state changes - a collapsible tool card, a copy button, an expandable thinking block - independent of how many items sit above it.

**Stacked on #93** (box-update-independence-default-on), which it depends on - rows survive a box re-render only because the stream-tail patch leaves the region intact. Review/merge #93 first; GitHub will retarget this to master.

## How

A row is an inline-mounted component inside the stream's region, so it reuses the existing inline scoped-rerender / interactivity / widget machinery - a row's `vui-set-state` re-renders just its region, no walk over the rest. The one genuinely tricky bit is marker coexistence: the row owns a region-end marker and so does the stream. The fix is to **share the last row's region-end marker as the stream's end**, so when the row grows or shrinks on its own re-render the stream end (and the box below) follow. `vui-stream-update-last` on a row updates its props in place, keeping the row's state. Content and rows interleave freely.

## The number that matters

Toggling a row (expand/collapse) vs items above it:

| N | row re-render |
|---|---------------|
| 200 | 0.15 ms |
| 1000 | 0.16 ms |
| 4000 | 0.20 ms |

Flat - a collapsible card in a 4000-line transcript opens as fast as in a 200-line one.

## Proven

`test/vui-stream-rows-test.el` (7 specs): parity with the same components rendered as declarative children (collapsed / expanded / last-only / round-trip - all byte-identical), box coexistence after the last row grows, scoped re-render (a marker in the box survives a row expanding), and update-last-on-row (props refresh, state preserved). 584 specs green flag off and on. The agent-chat demo now drops tool calls as collapsible rows interleaved with the typed-out messages.

## Honest limits (documented)

- A row needs the stream live and non-empty first; a component appended to an empty stream falls back to a plain child render (the empty->non-empty transition does a full re-render, which can't re-emit an inline row).
- Rows persist because the stream is never wholesale-re-emitted once they exist (the always-on stream-tail patch); they unmount with the buffer.