### PR TITLE
fix: keep point on its widget when a re-render shifts content above it

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -91,6 +91,29 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- Full-buffer re-renders no longer drop point onto the wrong widget (and
+  scroll the window to chase it) when content shifts above the cursor. A
+  jump I kept hitting in a dashboard of buttons and collapsible sections:
+  expanding a section re-renders the whole root, and my cursor would land a
+  row or two off, sometimes off-screen so Emacs re-scrolled to find it. I
+  traced it to cursor restoration matching widgets by =:vui-path= (with an
+  ordinal index fallback), both of which are just positions in the tree;
+  =vui-vstack= drops nil children, so a conditional row turning on shifts
+  every following sibling's path and index by one, and restore parked point
+  on the neighbour that had slid into the old slot. Restore now also records
+  a stable identity (a field's =:key=, otherwise the button or select label)
+  and, when the saved path resolves to a widget that no longer matches,
+  re-finds the original by that identity so point tracks the same logical
+  row. A row with no stable identity (say a checkbox, or a label that
+  encodes state) still falls back to its position, as before. While I was
+  there I fixed the matching viewport bug: =window-start= was restored to
+  its old absolute line, which is wrong once the number of lines above it
+  changed, so the window holding point now restores =window-start= relative
+  to point and the cursor's row stays where it visually was. Only that
+  window follows the cursor; other windows showing the buffer keep their own
+  scroll, so a background re-render does not yank a window the cursor does
+  not live in. Both live in the full-rebuild path and help every consumer,
+  independent of the experimental =vui-incremental-render= flag.
 - A =vui-stream='s first appended item no longer vanishes when the stream
   was re-rendered while still empty. An empty live stream was wrongly
   treated as eligible for the stream-tail patch, so a re-render of the

--- a/test/vui-rerender-test.el
+++ b/test/vui-rerender-test.el
@@ -353,5 +353,166 @@
               (expect (point) :to-equal 4))
           (kill-buffer "*rr-noop*"))))))
 
+;;; Cursor identity across a re-render that shifts content above point
+
+(describe "re-render preserves cursor identity"
+  (it "keeps point on the same widget when a row is inserted above it"
+    ;; A dashboard-style root: a fixed head row, an optional row, and a
+    ;; target row.  Expanding inserts the optional row ABOVE target,
+    ;; shifting target's buffer position and its :vui-path/ordinal index.
+    ;; Point must track the SAME logical widget, not drift onto the
+    ;; newly inserted neighbour that now occupies the old path.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-insert ()
+        :state ((expanded nil))
+        :render (vui-vstack
+                  (vui-button "head")
+                  (when expanded (vui-button "extra"))
+                  (vui-button "target")))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-insert) "*rr-ci*")))
+        (unwind-protect
+            (with-current-buffer "*rr-ci*"
+              (expect (buffer-string) :to-equal "[head]\n[target]")
+              ;; Park point on the "target" button (collapsed path (1)).
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(1)))))
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "target")
+              (let ((vui--current-instance inst)) (vui-set-state :expanded t))
+              (expect (buffer-string) :to-equal "[head]\n[extra]\n[target]")
+              ;; The old path (1) now resolves to "extra"; without stable
+              ;; identity point drifts there.
+              (expect (widget-get (widget-at (point)) :tag)
+                      :to-equal "target"))
+          (kill-buffer "*rr-ci*")))))
+
+  (it "keeps point on the same widget when a row is removed above it"
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-remove ()
+        :state ((expanded t))
+        :render (vui-vstack
+                  (vui-button "head")
+                  (when expanded (vui-button "extra"))
+                  (vui-button "target")))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-remove) "*rr-cr*")))
+        (unwind-protect
+            (with-current-buffer "*rr-cr*"
+              (expect (buffer-string) :to-equal "[head]\n[extra]\n[target]")
+              ;; Park point on "target" (expanded path (2)).
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(2)))))
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "target")
+              (let ((vui--current-instance inst)) (vui-set-state :expanded nil))
+              (expect (buffer-string) :to-equal "[head]\n[target]")
+              ;; The old path (2)/index 2 no longer exists; point must find
+              ;; "target" by identity rather than falling back to the head.
+              (expect (widget-get (widget-at (point)) :tag)
+                      :to-equal "target"))
+          (kill-buffer "*rr-cr*")))))
+
+  (it "keeps point on the same field when a row is inserted above it"
+    ;; Same shift, but the parked widget is an editable field, so the
+    ;; identity comes from its :key rather than a button label.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-field ()
+        :state ((expanded nil))
+        :render (vui-vstack
+                  (when expanded (vui-button "extra"))
+                  (vui-field :key 'target :value "abc" :size 6)))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-field) "*rr-cf2*")))
+        (unwind-protect
+            (with-current-buffer "*rr-cf2*"
+              (let ((field (vui--find-widget-by-path '(0))))
+                (goto-char (1+ (widget-field-start field))))
+              (let ((vui--current-instance inst)) (vui-set-state :expanded t))
+              ;; Point must sit inside the target field, not on "extra".
+              (let ((w (widget-at (point))))
+                (expect (widget-get w :vui-key) :to-equal 'target)))
+          (kill-buffer "*rr-cf2*"))))))
+
+;;; Viewport stays put when rows shift above point
+
+(describe "re-render preserves the viewport"
+  (it "keeps the cursor on the same screen row when rows shift above it"
+    ;; window-start is restored relative to point, so inserting rows
+    ;; above the cursor scrolls the viewport by the same amount: the
+    ;; cursor's widget keeps the screen row it had, no visible jump.
+    ;; Needs a live window, so the buffer is shown in the selected one.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-viewport ()
+        :state ((expanded nil))
+        :render (apply #'vui-vstack
+                       (append
+                        (when expanded
+                          (list (vui-button "x1")
+                                (vui-button "x2")
+                                (vui-button "x3")))
+                        (mapcar (lambda (i) (vui-button (format "row%d" i)))
+                                (number-sequence 1 40)))))
+      (let ((inst (vui-mount (vui-component 'rr-viewport) "*rr-vp*")))
+        (unwind-protect
+            (save-window-excursion
+              (let ((win (selected-window)))
+                (set-window-buffer win (get-buffer "*rr-vp*"))
+                (with-current-buffer "*rr-vp*"
+                  ;; Scroll down ten lines, then park point on "row20".
+                  (set-window-start
+                   win (save-excursion (goto-char (point-min))
+                                       (forward-line 9)
+                                       (point)))
+                  (goto-char (point-min))
+                  (search-forward "[row20]")
+                  (goto-char (match-beginning 0))
+                  (let ((screen-row (- (line-number-at-pos (point))
+                                       (line-number-at-pos
+                                        (window-start win)))))
+                    (expect (widget-get (widget-at (point)) :tag)
+                            :to-equal "row20")
+                    ;; Expand: three rows appear above both the viewport
+                    ;; and the cursor.
+                    (let ((vui--current-instance inst))
+                      (vui-set-state :expanded t))
+                    ;; Point still on row20 (identity), and the viewport
+                    ;; scrolled with it so the screen row is unchanged.
+                    (expect (widget-get (widget-at (point)) :tag)
+                            :to-equal "row20")
+                    (expect (- (line-number-at-pos (point))
+                               (line-number-at-pos (window-start win)))
+                            :to-equal screen-row)))))
+          (kill-buffer "*rr-vp*")))))
+
+  (it "leaves an unfocused window's scroll alone on re-render"
+    ;; Only the window holding point follows the cursor; a second window
+    ;; showing the same buffer (scrolled elsewhere, e.g. one a background
+    ;; re-render is not focused on) keeps its own window-start.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-viewport-mw ()
+        :state ((n 0))
+        :render (apply #'vui-vstack
+                       (mapcar (lambda (i) (vui-button (format "row%d-%d" i n)))
+                               (number-sequence 1 80))))
+      (let ((inst (vui-mount (vui-component 'rr-viewport-mw) "*rr-vpm*")))
+        (unwind-protect
+            (save-window-excursion
+              (let* ((w1 (selected-window)))
+                (set-window-buffer w1 (get-buffer "*rr-vpm*"))
+                (let ((w2 (split-window w1)))
+                  (with-current-buffer "*rr-vpm*"
+                    ;; Focused window scrolled near the top; unfocused
+                    ;; window scrolled far down.
+                    (set-window-start
+                     w1 (save-excursion (goto-char (point-min))
+                                        (forward-line 9) (point)))
+                    (goto-char (point-min))
+                    (set-window-point w1 (point))
+                    (set-window-start
+                     w2 (save-excursion (goto-char (point-min))
+                                        (forward-line 54) (point)))
+                    (let ((w2-before (line-number-at-pos (window-start w2))))
+                      (vui-rerender inst)
+                      ;; The unfocused window did not get yanked to point.
+                      (expect (line-number-at-pos (window-start w2))
+                              :to-equal w2-before))))))
+          (kill-buffer "*rr-vpm*"))))))
+
 (provide 'vui-rerender-test)
 ;;; vui-rerender-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -2400,27 +2400,53 @@ Returns a plist with :status, :data, and :error."
       (clrhash cache))))
 
 (defun vui--save-window-starts (buffer)
-  "Save `window-start' line numbers for all windows showing BUFFER.
-Returns alist of (WINDOW . LINE-NUMBER)."
-  (let ((result nil))
+  "Save viewport restoration data for all windows showing BUFFER.
+Returns an alist of (WINDOW . SPEC).  The window that holds point (the
+selected window when it shows BUFFER) gets (relative . DELTA), where
+DELTA is how many lines `window-start' sits above point; restoring by
+this delta keeps the cursor on the same screen row even when the
+re-render changes how many lines precede it, so the viewport does not
+visibly jump.  Every other window gets (absolute . LINE), its own
+`window-start' line, so a window the cursor does not live in (for
+instance one a background re-render is not focused on) keeps its own
+scroll position instead of being yanked to point.  See
+`vui--restore-window-starts'."
+  (let* ((selected (selected-window))
+         (cursor-window (and (eq (window-buffer selected) buffer) selected))
+         (point-line (line-number-at-pos (point)))
+         (result nil))
     (dolist (window (get-buffer-window-list buffer nil t))
-      (with-selected-window window
-        (let ((line (line-number-at-pos (window-start window))))
-          (push (cons window line) result))))
+      (let ((start-line (line-number-at-pos (window-start window))))
+        (push (cons window
+                    (if (eq window cursor-window)
+                        (cons 'relative (max 0 (- point-line start-line)))
+                      (cons 'absolute start-line)))
+              result)))
     result))
 
 (defun vui--restore-window-starts (window-info)
-  "Restore `window-start' positions from WINDOW-INFO.
-WINDOW-INFO is alist of (WINDOW . LINE-NUMBER)."
+  "Restore viewports saved by `vui--save-window-starts'.
+WINDOW-INFO is an alist of (WINDOW . SPEC).  Point is assumed to be
+already restored to the cursor's widget.  A (relative . DELTA) spec
+places `window-start' DELTA lines above point, keeping the cursor on
+the screen row it had; an (absolute . LINE) spec restores that
+window's own `window-start' line unchanged."
   (dolist (entry window-info)
     (let ((window (car entry))
-          (line (cdr entry)))
+          (spec (cdr entry)))
       (when (window-live-p window)
-        (with-selected-window window
-          (save-excursion
-            (goto-char (point-min))
-            (forward-line (1- line))
-            (set-window-start window (point))))))))
+        (let ((start (pcase spec
+                       (`(relative . ,delta)
+                        (save-excursion
+                          (forward-line (- delta))
+                          (line-beginning-position)))
+                       (`(absolute . ,line)
+                        (save-excursion
+                          (goto-char (point-min))
+                          (forward-line (1- line))
+                          (point))))))
+          (when start
+            (set-window-start window start)))))))
 
 (defun vui--flush-queued-rerenders ()
   "Re-render roots queued while a render was in progress.
@@ -2649,7 +2675,7 @@ For editable fields, returns the actual text area, not widget decoration."
 
 (defun vui--save-cursor-position (&optional start end)
   "Save cursor position relative to current widget.
-Returns plist with :path, :index, :offset for widgets,
+Returns plist with :path, :index, :identity, :offset for widgets,
 or :line, :column for non-widget positions.
 When START and END are given, widget indexing is scoped to that
 region (used by inline instances, which only manage a region)."
@@ -2660,8 +2686,9 @@ region (used by inline instances, which only manage a region)."
                (widget-start (car bounds))
                (offset (if widget-start (- pos widget-start) 0))
                (path (widget-get widget :vui-path))
-               (index (vui--widget-index widget start end)))
-          (list :path path :index index :offset offset))
+               (index (vui--widget-index widget start end))
+               (identity (vui--widget-identity widget)))
+          (list :path path :index index :identity identity :offset offset))
       ;; No widget at point - save line/column as fallback
       (list :line (line-number-at-pos) :column (current-column)))))
 
@@ -2712,6 +2739,42 @@ tree.  Bounds default to the whole buffer.  Returns nil if not found."
           (throw 'found w)))
       nil)))
 
+(defun vui--widget-identity (widget)
+  "Return a stable identity for WIDGET across re-renders, or nil.
+Uses an explicit field key when present, otherwise the button or
+select label.  Unlike `:vui-path' and the ordinal index, this does
+not change when content is inserted or removed above WIDGET, so it
+lets cursor restoration track the same logical widget after the
+surrounding rows shift."
+  (or (widget-get widget :vui-key)
+      (widget-get widget :tag)))
+
+(defun vui--find-widget-by-identity (identity &optional start end)
+  "Return the unique widget between START and END whose identity is IDENTITY.
+Identity is computed with `vui--widget-identity'.  Bounds default to
+the whole buffer.  Returns nil when IDENTITY is nil, when nothing
+matches, or when the match is ambiguous (more than one widget shares
+IDENTITY), so callers never guess between look-alikes."
+  (when identity
+    (let ((matches nil))
+      (dolist (w (vui--collect-widgets start end))
+        (when (equal (vui--widget-identity w) identity)
+          (push w matches)))
+      (when (and matches (null (cdr matches)))
+        (car matches)))))
+
+(defun vui--goto-widget-offset (widget offset)
+  "Move point into WIDGET, OFFSET characters past its start.
+Point is clamped to WIDGET's bounds; a nil OFFSET counts as 0."
+  (let* ((bounds (vui--widget-bounds widget))
+         (widget-start (car bounds))
+         (widget-end (cdr bounds)))
+    (when (and widget-start widget-end)
+      ;; Cap at (1- end) because bounds are exclusive on the right.
+      (goto-char (max widget-start
+                      (min (+ widget-start (or offset 0))
+                           (1- widget-end)))))))
+
 (defun vui--restore-cursor-position (cursor-info &optional start end)
   "Restore cursor from CURSOR-INFO saved by `vui--save-cursor-position'.
 When START and END are given, widget lookups are scoped to that
@@ -2719,34 +2782,36 @@ region and fallbacks move to START instead of the buffer beginning."
   (let* ((path (plist-get cursor-info :path))
          (index (plist-get cursor-info :index))
          (offset (plist-get cursor-info :offset))
+         (identity (plist-get cursor-info :identity))
          (line (plist-get cursor-info :line))
          (column (plist-get cursor-info :column))
          (home (or start (point-min)))
          ;; Single lookup for path-based matching
-         (path-widget (and path (vui--find-widget-by-path path start end))))
+         (path-widget (and path (vui--find-widget-by-path path start end)))
+         ;; The path is an ordinal position in the tree, so content
+         ;; inserted or removed above point shifts it onto a neighbour.
+         ;; When a stable identity was captured, only trust the path if
+         ;; the widget there still matches it; otherwise re-find the
+         ;; widget by identity so point tracks the same logical row.
+         (path-ok (and path-widget
+                       (or (null identity)
+                           (equal identity
+                                  (vui--widget-identity path-widget)))))
+         (identity-widget (and (not path-ok)
+                               (vui--find-widget-by-identity
+                                identity start end))))
     (cond
-     ;; Try path-based matching first (most robust)
-     (path-widget
-      (let* ((bounds (vui--widget-bounds path-widget))
-             (widget-start (car bounds))
-             (widget-end (cdr bounds)))
-        (when (and widget-start widget-end)
-          ;; Cap at (1- end) because bounds are exclusive on right
-          (goto-char (max widget-start
-                          (min (+ widget-start offset) (1- widget-end)))))))
+     ;; Path still resolves to the saved widget (most common, fast path)
+     (path-ok
+      (vui--goto-widget-offset path-widget offset))
+     ;; Path drifted: relocate the same widget by stable identity
+     (identity-widget
+      (vui--goto-widget-offset identity-widget offset))
      ;; Fall back to index-based matching
      (index
-      (let* ((widgets (vui--collect-widgets start end))
-             (widget (nth index widgets)))
+      (let ((widget (nth index (vui--collect-widgets start end))))
         (if widget
-            (let* ((bounds (vui--widget-bounds widget))
-                   (widget-start (car bounds))
-                   (widget-end (cdr bounds)))
-              (when (and widget-start widget-end)
-                ;; Cap at (1- end) because bounds are exclusive on right
-                (goto-char (max widget-start
-                                (min (+ widget-start offset)
-                                     (1- widget-end))))))
+            (vui--goto-widget-offset widget offset)
           (goto-char home))))
      ;; Fall back to line/column for non-widget positions
      ((and line column)


### PR DESCRIPTION
A jump I kept hitting in full-buffer vui apps (a dashboard of buttons with collapsible sections): expand a section and the whole root re-renders, and my cursor would drift a row or two off, sometimes off-screen so Emacs re-scrolled to chase it.

The cause is in cursor restoration. It matched the saved widget by `:vui-path`, with an ordinal `:index` fallback, both of which are just positions in the tree. `vui-vstack` strips nil children, so a conditional row turning on shifts every following sibling's path and index by one, and restore parked point on whatever neighbour slid into the old slot.

The fix: restoration now also records a stable identity (a field's `:key`, otherwise the button or select label) and, when the saved path resolves to a widget that no longer matches, re-finds the original by that identity so point tracks the same logical row. A row with no stable identity (a checkbox, or a label that encodes state) still falls back to its position, as before. Worst case stays a correct full redraw; it only ever moves point.

While I was in there I fixed the matching viewport bug: `window-start` was restored to its old absolute line, which is wrong once the number of lines above it changed, so the window holding point now restores `window-start` relative to point and the cursor's row stays where it visually was. Only that window follows the cursor; other windows showing the buffer keep their own scroll, so a background re-render (timers, streaming) does not yank a window the cursor does not live in.

Both live in the full-rebuild path and benefit every consumer, independent of the experimental `vui-incremental-render` flag.