### PR TITLE
fix: track the cursor by a widget's :key, not just its label

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -104,16 +104,30 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
   a stable identity (a field's =:key=, otherwise the button or select label)
   and, when the saved path resolves to a widget that no longer matches,
   re-finds the original by that identity so point tracks the same logical
-  row. A row with no stable identity (say a checkbox, or a label that
-  encodes state) still falls back to its position, as before. While I was
-  there I fixed the matching viewport bug: =window-start= was restored to
-  its old absolute line, which is wrong once the number of lines above it
-  changed, so the window holding point now restores =window-start= relative
-  to point and the cursor's row stays where it visually was. Only that
-  window follows the cursor; other windows showing the buffer keep their own
-  scroll, so a background re-render does not yank a window the cursor does
-  not live in. Both live in the full-rebuild path and help every consumer,
-  independent of the experimental =vui-incremental-render= flag.
+  row. A row with no stable identity still falls back to its position, as
+  before. While I was there I fixed the matching viewport bug: =window-start=
+  was restored to its old absolute line, which is wrong once the number of
+  lines above it changed, so the window holding point now restores
+  =window-start= relative to point and the cursor's row stays where it
+  visually was. Only that window follows the cursor; other windows showing
+  the buffer keep their own scroll, so a background re-render does not yank a
+  window the cursor does not live in. Both live in the full-rebuild path and
+  help every consumer, independent of the experimental =vui-incremental-render=
+  flag.
+- Cursor tracking across a re-render now follows a widget's =:key=, not just
+  its label, which covers the cases the first pass left on the table.
+  =vui-button=, =vui-checkbox= and =vui-select= already accept a =:key= for
+  reconciliation; that key now also rides on the widget, and
+  =vui--widget-identity= prefers it over the label. So a checkbox (no label
+  to match on) holds the cursor when rows shift above it, two buttons sharing
+  a label are told apart by their keys, and a keyed button or select whose
+  text changes in the same re-render (a counter, a select showing its current
+  choice) is still found by its key instead of drifting off. The key wins
+  because it is the stable identity, and since keys are only unique among
+  siblings (two lists can reuse one), restoration pairs the key with the
+  saved label to break ties, so a shared key no longer drifts the cursor
+  onto a same-key row in another list. Unkeyed widgets are unchanged, matched
+  by label and then position.
 - A =vui-stream='s first appended item no longer vanishes when the stream
   was re-rendered while still empty. An empty live stream was wrongly
   treated as eligible for the stream-tail patch, so a re-render of the

--- a/test/vui-rerender-test.el
+++ b/test/vui-rerender-test.el
@@ -427,7 +427,125 @@
               ;; Point must sit inside the target field, not on "extra".
               (let ((w (widget-at (point))))
                 (expect (widget-get w :vui-key) :to-equal 'target)))
-          (kill-buffer "*rr-cf2*"))))))
+          (kill-buffer "*rr-cf2*")))))
+
+  (it "tells two same-label buttons apart by :key when a row shifts in"
+    ;; Both rows render the label "dup", so the label alone is ambiguous;
+    ;; only the reconciliation :key distinguishes them.  Point must stay
+    ;; on the keyed button it started on, not the same-label neighbour.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-dup-key ()
+        :state ((expanded nil))
+        :render (vui-vstack
+                  (when expanded (vui-button "x"))
+                  (vui-button "dup" :key 'b1)
+                  (vui-button "dup" :key 'b2)))
+      (let ((inst (vui-mount (vui-component 'rr-dup-key) "*rr-dk*")))
+        (unwind-protect
+            (with-current-buffer "*rr-dk*"
+              ;; Park on the SECOND "dup" (key b2, collapsed path (1)).
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(1)))))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'b2)
+              (let ((vui--current-instance inst)) (vui-set-state :expanded t))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'b2))
+          (kill-buffer "*rr-dk*")))))
+
+  (it "keeps point on a keyed button whose label changes as a row shifts in"
+    ;; ONE re-render both inserts the row above and rewrites the label, so
+    ;; the label the cursor was saved with no longer exists anywhere.  The
+    ;; :key wins over the label and tracks the button; matching on the
+    ;; label paired with the key (which would drift here) is what this
+    ;; pins down.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-counter-key ()
+        :state ((n 5))
+        :render (vui-vstack
+                  (when (> n 5) (vui-button "x"))
+                  (vui-button (format "count %d" n) :key 'counter)))
+      (let ((inst (vui-mount (vui-component 'rr-counter-key) "*rr-ck*")))
+        (unwind-protect
+            (with-current-buffer "*rr-ck*"
+              (expect (buffer-string) :to-equal "[count 5]")
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(0)))))
+              (expect (widget-get (widget-at (point)) :vui-key)
+                      :to-equal 'counter)
+              ;; Single state change: inserts "x" AND relabels the counter.
+              (let ((vui--current-instance inst)) (vui-set-state :n 6))
+              (expect (buffer-string) :to-equal "[x]\n[count 6]")
+              (expect (widget-get (widget-at (point)) :vui-key)
+                      :to-equal 'counter))
+          (kill-buffer "*rr-ck*")))))
+
+  (it "keeps point on a keyed checkbox when a row is inserted above it"
+    ;; A checkbox carries no label, so before keys reached the widget it
+    ;; had no stable identity and drifted; its :key now anchors it.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cb-key ()
+        :state ((expanded nil))
+        :render (vui-vstack
+                  (when expanded (vui-button "x"))
+                  (vui-checkbox :key 'agree :label "Agree")))
+      (let ((inst (vui-mount (vui-component 'rr-cb-key) "*rr-cbk*")))
+        (unwind-protect
+            (with-current-buffer "*rr-cbk*"
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(0)))))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'agree)
+              (let ((vui--current-instance inst)) (vui-set-state :expanded t))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'agree))
+          (kill-buffer "*rr-cbk*")))))
+
+  (it "keeps point on a keyed select as its label shifts in a single render"
+    ;; A select's visible text is its current selection.  One state change
+    ;; inserts a row above and changes the selection, so the :key on the
+    ;; select widget is what keeps the cursor on it.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-sel-key ()
+        :state ((val "a"))
+        :render (vui-vstack
+                  (when (equal val "b") (vui-button "x"))
+                  (vui-select :key 'sel :value val
+                              :options '("a" "b"))))
+      (let ((inst (vui-mount (vui-component 'rr-sel-key) "*rr-sk2*")))
+        (unwind-protect
+            (with-current-buffer "*rr-sk2*"
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(0)))))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'sel)
+              (let ((vui--current-instance inst)) (vui-set-state :val "b"))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'sel))
+          (kill-buffer "*rr-sk2*")))))
+
+  (it "tells same-:key widgets in different lists apart by label"
+    ;; Keys are only unique among siblings, so two separate lists can reuse
+    ;; one key.  When a row shifts the saved path onto the same-key sibling,
+    ;; the key alone is ambiguous; the label breaks the tie so point stays
+    ;; on the row it started on instead of jumping to the other list.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cross-key ()
+        :state ((expanded nil))
+        :render (vui-vstack
+                  (when expanded (vui-button "top"))
+                  (vui-vstack (vui-button "Apple" :key 'item-1))
+                  (vui-vstack (vui-button "Banana" :key 'item-1))))
+      (let ((inst (vui-mount (vui-component 'rr-cross-key) "*rr-xk*")))
+        (unwind-protect
+            (with-current-buffer "*rr-xk*"
+              (expect (buffer-string) :to-equal "[Apple]\n[Banana]")
+              ;; Park on "Banana" (second list, path (1 0)); both buttons
+              ;; carry key item-1.
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(1 0)))))
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "Banana")
+              (let ((vui--current-instance inst)) (vui-set-state :expanded t))
+              (expect (buffer-string) :to-equal "[top]\n[Apple]\n[Banana]")
+              ;; The old path (1 0) now resolves to "Apple" (same key); point
+              ;; must follow "Banana", not drift onto the look-alike.
+              (expect (widget-get (widget-at (point)) :tag)
+                      :to-equal "Banana"))
+          (kill-buffer "*rr-xk*"))))))
 
 ;;; Viewport stays put when rows shift above point
 

--- a/vui.el
+++ b/vui.el
@@ -2675,8 +2675,11 @@ For editable fields, returns the actual text area, not widget decoration."
 
 (defun vui--save-cursor-position (&optional start end)
   "Save cursor position relative to current widget.
-Returns plist with :path, :index, :identity, :offset for widgets,
-or :line, :column for non-widget positions.
+Returns plist with :path, :index, :identity, :label, :offset for
+widgets, or :line, :column for non-widget positions.  :label is the
+widget's `:tag', kept alongside :identity so a key shared across the
+buffer can be disambiguated on restore (see
+`vui--find-widget-by-identity').
 When START and END are given, widget indexing is scoped to that
 region (used by inline instances, which only manage a region)."
   (let ((widget (widget-at (point)))
@@ -2687,8 +2690,10 @@ region (used by inline instances, which only manage a region)."
                (offset (if widget-start (- pos widget-start) 0))
                (path (widget-get widget :vui-path))
                (index (vui--widget-index widget start end))
-               (identity (vui--widget-identity widget)))
-          (list :path path :index index :identity identity :offset offset))
+               (identity (vui--widget-identity widget))
+               (label (widget-get widget :tag)))
+          (list :path path :index index :identity identity
+                :label label :offset offset))
       ;; No widget at point - save line/column as fallback
       (list :line (line-number-at-pos) :column (current-column)))))
 
@@ -2741,27 +2746,49 @@ tree.  Bounds default to the whole buffer.  Returns nil if not found."
 
 (defun vui--widget-identity (widget)
   "Return a stable identity for WIDGET across re-renders, or nil.
-Uses an explicit field key when present, otherwise the button or
-select label.  Unlike `:vui-path' and the ordinal index, this does
-not change when content is inserted or removed above WIDGET, so it
-lets cursor restoration track the same logical widget after the
-surrounding rows shift."
+Prefers WIDGET's reconciliation key (`:vui-key', set on fields,
+buttons, checkboxes and selects that carry a :key), falling back to
+its label (`:tag').  Unlike `:vui-path' and the ordinal index, neither
+changes when content is inserted or removed above WIDGET, so this lets
+cursor restoration track the same logical widget after the surrounding
+rows shift.  The key wins over the label because it stays stable even
+when the displayed text changes (a counter button, a select showing
+its current choice), and it tells same-label widgets apart.  Keys are
+only unique among siblings, so two lists can reuse one; restoration
+pairs this identity with the saved label to break such ties (see
+`vui--find-widget-by-identity'), so a shared key does not collapse two
+distinct rows.  Returns nil when WIDGET has neither key nor label, so
+an identity-less widget falls back to ordinal position as before."
   (or (widget-get widget :vui-key)
       (widget-get widget :tag)))
 
-(defun vui--find-widget-by-identity (identity &optional start end)
-  "Return the unique widget between START and END whose identity is IDENTITY.
-Identity is computed with `vui--widget-identity'.  Bounds default to
-the whole buffer.  Returns nil when IDENTITY is nil, when nothing
-matches, or when the match is ambiguous (more than one widget shares
-IDENTITY), so callers never guess between look-alikes."
+(defun vui--find-widget-by-identity (identity label &optional start end)
+  "Return the widget between START and END identified by IDENTITY and LABEL.
+IDENTITY is computed with `vui--widget-identity' (the reconciliation
+key, or the label when unkeyed); LABEL is the saved `:tag'.  The key is
+matched first, so a keyed widget is found even when its label changed.
+Keys are only unique among siblings, so a key can repeat across the
+buffer; when more than one widget shares IDENTITY, LABEL breaks the tie
+(the one in another list with a different label is rejected).  Bounds
+default to the whole buffer.  Returns nil when IDENTITY is nil, nothing
+matches, or the choice stays ambiguous, so callers never guess between
+true look-alikes."
   (when identity
     (let ((matches nil))
       (dolist (w (vui--collect-widgets start end))
         (when (equal (vui--widget-identity w) identity)
           (push w matches)))
-      (when (and matches (null (cdr matches)))
-        (car matches)))))
+      (cond
+       ((null matches) nil)
+       ;; Unique by identity: trust it even if the label changed.
+       ((null (cdr matches)) (car matches))
+       ;; Identity collides (a key reused across lists): keep only the
+       ;; widget whose label also matches, and only if that is unique.
+       (t (let ((by-label (seq-filter
+                           (lambda (w) (equal (widget-get w :tag) label))
+                           matches)))
+            (when (and by-label (null (cdr by-label)))
+              (car by-label))))))))
 
 (defun vui--goto-widget-offset (widget offset)
   "Move point into WIDGET, OFFSET characters past its start.
@@ -2783,6 +2810,7 @@ region and fallbacks move to START instead of the buffer beginning."
          (index (plist-get cursor-info :index))
          (offset (plist-get cursor-info :offset))
          (identity (plist-get cursor-info :identity))
+         (label (plist-get cursor-info :label))
          (line (plist-get cursor-info :line))
          (column (plist-get cursor-info :column))
          (home (or start (point-min)))
@@ -2791,15 +2819,19 @@ region and fallbacks move to START instead of the buffer beginning."
          ;; The path is an ordinal position in the tree, so content
          ;; inserted or removed above point shifts it onto a neighbour.
          ;; When a stable identity was captured, only trust the path if
-         ;; the widget there still matches it; otherwise re-find the
-         ;; widget by identity so point tracks the same logical row.
+         ;; the widget there still matches it (both key and label, so a
+         ;; same-key sibling that slid into the slot is rejected);
+         ;; otherwise re-find the widget by identity so point tracks the
+         ;; same logical row.
          (path-ok (and path-widget
                        (or (null identity)
-                           (equal identity
-                                  (vui--widget-identity path-widget)))))
+                           (and (equal identity
+                                       (vui--widget-identity path-widget))
+                                (equal label
+                                       (widget-get path-widget :tag))))))
          (identity-widget (and (not path-ok)
                                (vui--find-widget-by-identity
-                                identity start end))))
+                                identity label start end))))
     (cond
      ;; Path still resolves to the saved widget (most common, fast path)
      (path-ok
@@ -4778,7 +4810,11 @@ wholesale render's empty-child handling)."
                        (when keymap
                          (list :keymap keymap))))))
         ;; Store path for cursor tracking
-        (widget-put w :vui-path captured-path))))
+        (widget-put w :vui-path captured-path)
+        ;; Store reconciliation key so cursor identity can tell
+        ;; same-label buttons apart (see `vui--widget-identity')
+        (when-let* ((key (vui-vnode-button-key vnode)))
+          (widget-put w :vui-key key)))))
 
    ;; Checkbox
    ((vui-vnode-checkbox-p vnode)
@@ -4799,7 +4835,11 @@ wholesale render's empty-child handling)."
                                                 (vui--root-instance captured-root))
                                             (funcall wrapped-change (widget-value widget))))))))
         ;; Store path for cursor tracking
-        (widget-put w :vui-path captured-path))
+        (widget-put w :vui-path captured-path)
+        ;; A checkbox has no label, so its :key is its only stable
+        ;; cursor identity (see `vui--widget-identity')
+        (when-let* ((key (vui-vnode-checkbox-key vnode)))
+          (widget-put w :vui-key key)))
       (when label
         (insert " " label))))
 
@@ -4841,7 +4881,12 @@ wholesale render's empty-child handling)."
                                             (funcall wrapped-change (cdr chosen)))))
                               (format "%s" (or current-label "Select...")))))
         ;; Store path for cursor tracking
-        (widget-put w :vui-path captured-path))))
+        (widget-put w :vui-path captured-path)
+        ;; Store reconciliation key for cursor identity, since the
+        ;; button label reflects the current selection (see
+        ;; `vui--widget-identity')
+        (when-let* ((key (vui-vnode-select-key vnode)))
+          (widget-put w :vui-key key)))))
 
    ;; Horizontal stack
    ;; Children that render to nothing (e.g., components returning nil)


### PR DESCRIPTION
Follow-up to #101. That fix gave cursor restoration a stable identity so point stops drifting when rows shift above it, but the identity only used a field's `:key`; buttons, checkboxes and selects fell back to their label because their `:key` never made it onto the widget. So a few cases were still left on the table:

- a checkbox has no label, so it had no stable identity and still drifted when rows shifted above it
- two buttons with the same label could not be told apart
- a keyed button or select whose text changes in a re-render (a counter, a select showing its current choice) was matched on stale label text and could drift

Now `vui-button`, `vui-checkbox` and `vui-select` store their reconciliation `:key` on the widget, and `vui--widget-identity` prefers it over the label. The key is the right identity here: it survives the displayed text changing, and it tells same-label widgets apart.

Keys are only unique among siblings, so two separate lists can legitimately reuse one. To keep that from drifting the cursor onto a same-key row in the other list, restore keeps the saved label alongside the key and uses it to break ties: prefer the key, and when a key is shared, the label picks the right one. Unkeyed widgets are unchanged (matched by label, then position).