### PR TITLE
fix: keep point on a collapsible's toggle across expand and collapse

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -91,6 +91,22 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-collapsible= now keeps point on its header toggle across expand and
+  collapse, out of the box. The toggle bakes the ▶/▼ indicator into its
+  label, so the label flips on every toggle, and the button carried no
+  =:key=, which left its label as the only cursor identity. On its own that
+  was masked by the position fallback, but the moment a re-render also shifts
+  the toggle (a sibling row appearing above it, another section expanding),
+  the path, the index and the now-changed label all miss at once and point
+  jumped off, to =point-min= in the worst case. It hit everything built on
+  the primitive, collapsible sidebars especially, and the =:key= a caller
+  passed was only used for reconciliation, never handed down to the toggle,
+  so there was no fixing it from outside either. The toggle now takes a
+  stable key (the caller's =:key=, or the title when none is given) so
+  =vui--widget-identity= re-finds it after the label flips. One honest gap:
+  two collapsibles that share a title and set no =:key= still have ambiguous
+  toggles and fall back to the old position-based behavior, no worse than
+  before; a unique title or an explicit =:key= now tracks correctly.
 - Full-buffer re-renders no longer drop point onto the wrong widget (and
   scroll the window to chase it) when content shifts above the cursor. A
   jump I kept hitting in a dashboard of buttons and collapsible sections:

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -21,6 +21,11 @@ Buttons are widget.el push-buttons, so we use widget-apply."
     (when widget
       (widget-apply widget :action))))
 
+(defun vui-components-test--widget-by-tag (tag)
+  "Return the first buffer widget whose :tag is TAG, or nil."
+  (seq-find (lambda (w) (equal (widget-get w :tag) tag))
+            (vui--collect-widgets)))
+
 (describe "vui type conversion functions"
   (describe "vui--field-value-to-string"
     (it "returns empty string for nil value with type"
@@ -532,7 +537,105 @@ Buttons are widget.el push-buttons, so we use widget-apply."
               (forward-line 1)
               ;; Line 4: "    Inner content" at column 4 (accumulated indent)
               (expect (looking-at "    Inner content") :to-be-truthy))
-          (kill-buffer "*test-collapsible-16*"))))))
+          (kill-buffer "*test-collapsible-16*")))))
+
+  (describe "cursor identity across expand and collapse"
+    ;; The header toggle bakes the ▶/▼ indicator into its label, so the
+    ;; label flips on every toggle.  When a re-render also shifts the
+    ;; toggle down (a row appears above it in the same render), neither the
+    ;; ordinal path nor the widget index still points at it, and the
+    ;; flipped label defeats label-based cursor identity: point drifts onto
+    ;; the new row.  A stable :key on the toggle, derived from the title or
+    ;; passed by the caller, keeps point on it.
+
+    (it "keeps point on the toggle when a row shifts in as it expands"
+      (let ((vui-render-delay nil))
+        (vui-defcomponent cc-toggle-shift ()
+          :state ((open nil))
+          :render
+          (vui-vstack
+           ;; Appears in the SAME render that expands the section, so the
+           ;; toggle both moves down and flips its indicator at once.
+           (when open (vui-button "banner"))
+           (vui-collapsible :title "Details" :expanded open
+             (vui-text "body"))))
+        (let ((inst (vui-mount (vui-component 'cc-toggle-shift) "*cc-ts*")))
+          (unwind-protect
+              (with-current-buffer "*cc-ts*"
+                (expect (buffer-string) :to-equal "▶ Details")
+                (goto-char (car (vui--widget-bounds
+                                 (vui-components-test--widget-by-tag
+                                  "▶ Details"))))
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▶ Details")
+                (let ((vui--current-instance inst)) (vui-set-state :open t))
+                ;; Row inserted above AND indicator flipped in one render;
+                ;; point must ride the toggle, not drift onto "banner".
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▼ Details"))
+            (kill-buffer "*cc-ts*")))))
+
+    (it "keeps point on the right toggle via :key when titles repeat"
+      (let ((vui-render-delay nil))
+        (vui-defcomponent cc-toggle-dup ()
+          :state ((open nil))
+          :render
+          (vui-vstack
+           (when open (vui-button "banner"))
+           (vui-collapsible :title "Item" :key 'a
+             (vui-text "a-body"))
+           (vui-collapsible :title "Item" :key 'b :expanded open
+             (vui-text "b-body"))))
+        (let ((inst (vui-mount (vui-component 'cc-toggle-dup) "*cc-dup*")))
+          (unwind-protect
+              (with-current-buffer "*cc-dup*"
+                ;; Park on the SECOND "Item" toggle (key b); the two share a
+                ;; title, so only the caller's :key tells them apart.
+                (let ((toggles (seq-filter
+                                (lambda (w)
+                                  (equal (widget-get w :tag) "▶ Item"))
+                                (vui--collect-widgets))))
+                  (goto-char (car (vui--widget-bounds (nth 1 toggles)))))
+                (let ((vui--current-instance inst)) (vui-set-state :open t))
+                ;; Banner shifts both toggles down and the second's indicator
+                ;; flips; without the caller's :key threaded to the toggle,
+                ;; point drifts onto the first "Item".
+                (expect (widget-get (widget-at (point)) :vui-key)
+                        :to-equal 'b)
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▼ Item"))
+            (kill-buffer "*cc-dup*")))))
+
+    (it "keeps point on a sibling toggle when the section above it expands"
+      ;; Regression guard: expanding the FIRST collapsible inserts content
+      ;; above the SECOND.  The second's label does not change, so this
+      ;; already works via the stable path; the toggle key must not
+      ;; regress it.
+      (let ((vui-render-delay nil))
+        (vui-defcomponent cc-sibling ()
+          :render
+          (vui-vstack
+           (vui-collapsible :title "Foo"
+             (vui-button "inside-foo"))
+           (vui-collapsible :title "Bar"
+             (vui-button "inside-bar"))))
+        (let ((inst (vui-mount (vui-component 'cc-sibling) "*cc-sib*")))
+          (ignore inst)
+          (unwind-protect
+              (with-current-buffer "*cc-sib*"
+                (goto-char (car (vui--widget-bounds
+                                 (vui-components-test--widget-by-tag
+                                  "▶ Bar"))))
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▶ Bar")
+                ;; Expand Foo by invoking its header toggle.
+                (widget-apply (vui-components-test--widget-by-tag "▶ Foo")
+                              :action)
+                (vui-flush-sync)
+                (expect (buffer-string) :to-match "inside-foo")
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▶ Bar"))
+            (kill-buffer "*cc-sib*")))))))
 
 (defun vui-components-test--placeholder-overlays ()
   "Return all placeholder overlays in the current buffer."

--- a/vui-components.el
+++ b/vui-components.el
@@ -184,7 +184,8 @@ Returns nil if valid, or an error message string if invalid."
 
 (vui-defcomponent vui-collapsible--internal
     (title expanded on-toggle title-face
-     expanded-indicator collapsed-indicator indent initially-expanded)
+     expanded-indicator collapsed-indicator indent initially-expanded
+     toggle-key)
   "Internal component for collapsible sections.
 
 TITLE is the header text (required).
@@ -194,7 +195,9 @@ TITLE-FACE is the face for the header text.
 EXPANDED-INDICATOR is shown when expanded (default \"▼\").
 COLLAPSED-INDICATOR is shown when collapsed (default \"▶\").
 INDENT is the content indentation level (default 2).
-INITIALLY-EXPANDED sets initial state for uncontrolled mode."
+INITIALLY-EXPANDED sets initial state for uncontrolled mode.
+TOGGLE-KEY is the header toggle's cursor-identity key; it falls back
+to TITLE so the ▶/▼ indicator flip does not move point off the toggle."
 
   :state ((internal-expanded :unset))
 
@@ -217,10 +220,16 @@ INITIALLY-EXPANDED sets initial state for uncontrolled mode."
          (total-indent (+ parent-indent own-indent)))
     (vui-fragment
      ;; Header - plain clickable text (no indent - inherits from parent)
+     ;; The ▶/▼ indicator is baked into the label, so the label changes on
+     ;; every toggle.  Give the button a stable :key (the caller's key, or
+     ;; the title as a fallback) so cursor restoration keeps point on the
+     ;; toggle across expand/collapse instead of losing it when the label
+     ;; flips (see `vui--widget-identity').
      (vui-button (format "%s %s" indicator title)
        :no-decoration t
        :face title-face
        :help-echo nil
+       :key (or toggle-key title)
        :on-click (lambda ()
                    (let ((new-state (not is-expanded)))
                      (unless is-controlled
@@ -252,7 +261,13 @@ Options:
   :expanded-indicator STRING - shown when expanded (default \"▼\")
   :collapsed-indicator STRING - shown when collapsed (default \"▶\")
   :indent N - content indentation (default 2)
-  :key KEY - for reconciliation
+  :key KEY - reconciliation key.  It also becomes the header toggle's
+             cursor identity, so point rides the toggle across
+             expand/collapse.  When omitted, only that toggle identity
+             falls back to the title (reconciliation stays unkeyed).
+             Pass an explicit KEY when several collapsibles share a
+             title, otherwise their toggles stay ambiguous and cursor
+             tracking falls back to position.
 
 Usage:
   (vui-collapsible :title \"Section\" child1 child2)
@@ -291,6 +306,10 @@ Usage:
       :collapsed-indicator collapsed-indicator
       :indent indent
       :key key
+      ;; Also hand the key to the toggle button (falls back to the title
+      ;; inside the component) so its cursor identity survives the label
+      ;; flip; this is separate from the reconciliation :key above.
+      :toggle-key key
       :children children)))
 
 ;;; Semantic Text Faces


### PR DESCRIPTION
Follow-up to the recent cursor-tracking work: that made full-buffer restore track widgets by a stable identity (a `:key`, else the label), but the shared `vui-collapsible` primitive never got the memo.

Its header toggle bakes the ▶/▼ indicator into the button label, so the label flips on every toggle, and the button carried no `:key`. That left the flipping label as its only cursor identity. On its own the position fallback hid the problem, but the moment a re-render also shifts the toggle (a sibling row showing up above it, another section expanding) the path, the index and the now-changed label all miss at once and point jumps off, to `point-min` in the worst case. This hit everything built on the primitive, collapsible sidebars especially. And the `:key` a caller passed was only used for reconciliation, never handed to the toggle, so there was no fixing it from the outside either.

The fix threads the caller's key down to the toggle button (a new internal `toggle-key` prop), falling back to the title when no key is given, so `vui--widget-identity` re-finds the toggle after the label flips. The reconciliation `:key` behaviour is untouched.

One honest gap, called out in the docstring and CHANGELOG: two collapsibles that share a title and set no `:key` still have ambiguous toggles and fall back to the old position-based behaviour, no worse than today. A unique title, or an explicit `:key` when titles repeat, now tracks correctly.