### PR TITLE
feat: rich headers for vui-collapsible via :header-right

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,21 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-collapsible= takes a rich header. =:header-right= puts a vnode (a
+  count, a badge, a status) right-aligned in the header row opposite the
+  toggle, and =:header-width= (anything =vui-flex='s =:width= accepts, default
+  =fill-column=) sets what it aligns to. I wanted a dashboard section that
+  reads "▶ SchemaName ............ 3 invalid", toggle on the left, count pinned
+  to the window edge, without hand-rolling the header and losing the toggle's
+  cursor identity to do it. With =:header-right= the header becomes a
+  space-between =vui-flex=; without it the header is exactly the toggle as
+  before, byte for byte, so nothing that does not ask for a right side changes.
+  The right content is adornment: always shown in the header row (not a body
+  child that hides when collapsed) and presentational (the toggle stays the
+  only clickable part). The toggle keeps the stable =:key= from #103 so point
+  rides it across expand and collapse, and a nested collapsible's header
+  subtracts its own indent so the right edge still lands at =:header-width=
+  however deep it sits.
 - =vui-stream= - an imperative, append-only region for unbounded streaming
   content (chat transcripts, build logs), the one shape the declarative
   "re-render from state" model is too slow for: it rebuilds all N items on

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -635,7 +635,132 @@ Buttons are widget.el push-buttons, so we use widget-apply."
                 (expect (buffer-string) :to-match "inside-foo")
                 (expect (widget-get (widget-at (point)) :tag)
                         :to-equal "▶ Bar"))
-            (kill-buffer "*cc-sib*")))))))
+            (kill-buffer "*cc-sib*"))))))
+
+  (describe "rich header"
+    (it "right-aligns :header-right at :header-width via space-between"
+      (vui-defcomponent cc-rich-align ()
+        :render
+        (vui-collapsible :title "Schema"
+                         :header-width 20
+                         :header-right (vui-text "3 invalid")
+          (vui-text "body")))
+      (let ((instance (vui-mount (vui-component 'cc-rich-align)
+                                 "*cc-rich-align*")))
+        (ignore instance)
+        (unwind-protect
+            (with-current-buffer "*cc-rich-align*"
+              (goto-char (point-min))
+              (let ((line (buffer-substring-no-properties
+                           (line-beginning-position) (line-end-position))))
+                ;; Toggle flush left, right content flush to header-width.
+                (expect line :to-match "\\`▶ Schema")
+                (expect line :to-match "3 invalid\\'")
+                (expect (string-width line) :to-equal 20)))
+          (kill-buffer "*cc-rich-align*"))))
+
+    (it "keeps :header-right visible in the header row when collapsed"
+      ;; It is header adornment, not a child: shown even while the body
+      ;; is hidden.
+      (vui-defcomponent cc-rich-collapsed ()
+        :render
+        (vui-collapsible :title "Schema"
+                         :header-width 30
+                         :header-right (vui-text "3 invalid")
+          (vui-text "secret-body")))
+      (let ((instance (vui-mount (vui-component 'cc-rich-collapsed)
+                                 "*cc-rich-collapsed*")))
+        (ignore instance)
+        (unwind-protect
+            (with-current-buffer "*cc-rich-collapsed*"
+              (expect (buffer-string) :to-match "▶ Schema")
+              (expect (buffer-string) :to-match "3 invalid")
+              (expect (buffer-string) :not :to-match "secret-body"))
+          (kill-buffer "*cc-rich-collapsed*"))))
+
+    (it "toggles and keeps point on the toggle with a rich header"
+      (let ((vui-render-delay nil))
+        (vui-defcomponent cc-rich-toggle ()
+          :render
+          (vui-collapsible :title "Schema"
+                           :header-width 30
+                           :header-right (vui-text "3 invalid")
+            (vui-text "body")))
+        (let ((instance (vui-mount (vui-component 'cc-rich-toggle)
+                                   "*cc-rich-toggle*")))
+          (ignore instance)
+          (unwind-protect
+              (with-current-buffer "*cc-rich-toggle*"
+                (expect (buffer-string) :not :to-match "body")
+                (goto-char (car (vui--widget-bounds
+                                 (vui-components-test--widget-by-tag
+                                  "▶ Schema"))))
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▶ Schema")
+                (vui-components-test--click-button-at (point))
+                (vui-flush-sync)
+                ;; Expanded: body visible, right content still in the header.
+                (expect (buffer-string) :to-match "body")
+                (expect (buffer-string) :to-match "3 invalid")
+                ;; Point rode the toggle across the label flip (#103).
+                (expect (widget-get (widget-at (point)) :tag)
+                        :to-equal "▼ Schema"))
+            (kill-buffer "*cc-rich-toggle*")))))
+
+    (it "defaults :header-width to fill-column"
+      (vui-defcomponent cc-rich-default ()
+        :render
+        (vui-collapsible :title "Schema"
+                         :header-right (vui-text "9")
+          (vui-text "body")))
+      (let ((instance (vui-mount (vui-component 'cc-rich-default)
+                                 "*cc-rich-default*")))
+        (ignore instance)
+        (unwind-protect
+            (with-current-buffer "*cc-rich-default*"
+              (goto-char (point-min))
+              (let ((line (buffer-substring-no-properties
+                           (line-beginning-position) (line-end-position))))
+                (expect (string-width line) :to-equal fill-column)))
+          (kill-buffer "*cc-rich-default*"))))
+
+    (it "leaves the header unchanged when :header-right is absent"
+      ;; No flex wrapper, no padding: the header is exactly the toggle.
+      (vui-defcomponent cc-plain-header ()
+        :render
+        (vui-collapsible :title "Section"
+          (vui-text "body")))
+      (let ((instance (vui-mount (vui-component 'cc-plain-header)
+                                 "*cc-plain-header*")))
+        (ignore instance)
+        (unwind-protect
+            (with-current-buffer "*cc-plain-header*"
+              (expect (buffer-string) :to-equal "▶ Section"))
+          (kill-buffer "*cc-plain-header*"))))
+
+    (it "indents a nested collapsible's rich header correctly"
+      (vui-defcomponent cc-rich-nested ()
+        :render
+        (vui-collapsible :title "Outer" :initially-expanded t
+          (vui-collapsible :title "Inner" :initially-expanded t
+                           :header-width 20
+                           :header-right (vui-text "9")
+            (vui-text "deep"))))
+      (let ((instance (vui-mount (vui-component 'cc-rich-nested)
+                                 "*cc-rich-nested*")))
+        (ignore instance)
+        (unwind-protect
+            (with-current-buffer "*cc-rich-nested*"
+              (goto-char (point-min))
+              (expect (looking-at "▼ Outer") :to-be-truthy)
+              (forward-line 1)
+              ;; Line 2 is the inner rich header, indented by 2.
+              (let ((line (buffer-substring-no-properties
+                           (line-beginning-position) (line-end-position))))
+                (expect line :to-match "\\`  ▼ Inner")
+                (expect line :to-match "9\\'")
+                (expect (string-width line) :to-equal 20)))
+          (kill-buffer "*cc-rich-nested*"))))))
 
 (defun vui-components-test--placeholder-overlays ()
   "Return all placeholder overlays in the current buffer."

--- a/vui-components.el
+++ b/vui-components.el
@@ -185,7 +185,7 @@ Returns nil if valid, or an error message string if invalid."
 (vui-defcomponent vui-collapsible--internal
     (title expanded on-toggle title-face
      expanded-indicator collapsed-indicator indent initially-expanded
-     toggle-key)
+     toggle-key header-right header-width)
   "Internal component for collapsible sections.
 
 TITLE is the header text (required).
@@ -197,7 +197,11 @@ COLLAPSED-INDICATOR is shown when collapsed (default \"▶\").
 INDENT is the content indentation level (default 2).
 INITIALLY-EXPANDED sets initial state for uncontrolled mode.
 TOGGLE-KEY is the header toggle's cursor-identity key; it falls back
-to TITLE so the ▶/▼ indicator flip does not move point off the toggle."
+to TITLE so the ▶/▼ indicator flip does not move point off the toggle.
+HEADER-RIGHT is a vnode rendered right-aligned opposite the toggle; when
+set the header becomes a `vui-flex' with `:justify :space-between'.
+HEADER-WIDTH is the width for that alignment (see `vui-flex' `:width',
+default `fill-column'); it only matters when HEADER-RIGHT is set."
 
   :state ((internal-expanded :unset))
 
@@ -217,25 +221,43 @@ to TITLE so the ▶/▼ indicator flip does not move point off the toggle."
          ;; Indentation: own indent + accumulated from parent
          (own-indent (or indent 2))
          (parent-indent (vui-use-context vui-collapsible-indent-context))
-         (total-indent (+ parent-indent own-indent)))
+         (total-indent (+ parent-indent own-indent))
+         ;; The toggle - plain clickable text (no indent - inherits from
+         ;; parent).  The ▶/▼ indicator is baked into the label, so the
+         ;; label changes on every toggle.  Give the button a stable :key
+         ;; (the caller's key, or the title as a fallback) so cursor
+         ;; restoration keeps point on the toggle across expand/collapse
+         ;; instead of losing it when the label flips (see
+         ;; `vui--widget-identity').  Built here so it is byte-for-byte the
+         ;; same whether or not it ends up inside the rich-header flex.
+         (toggle (vui-button (format "%s %s" indicator title)
+                   :no-decoration t
+                   :face title-face
+                   :help-echo nil
+                   :key (or toggle-key title)
+                   :on-click (lambda ()
+                               (let ((new-state (not is-expanded)))
+                                 (unless is-controlled
+                                   (vui-set-state :internal-expanded new-state))
+                                 (when on-toggle
+                                   (funcall on-toggle new-state))))))
+         ;; With :header-right, the header is a space-between flex (toggle
+         ;; on the left, adornment on the right); without it, the header is
+         ;; exactly the toggle button, unchanged from before.  The header
+         ;; sits at PARENT-INDENT (the body goes deeper, at TOTAL-INDENT),
+         ;; so tell the flex to subtract PARENT-INDENT from its width: the
+         ;; right edge then lands at HEADER-WIDTH no matter how deeply the
+         ;; collapsible is nested, instead of drifting past it by the
+         ;; indent.
+         (header (if header-right
+                     (vui-flex :width (or header-width 'fill-column)
+                               :justify :space-between
+                               :indent parent-indent
+                       toggle
+                       header-right)
+                   toggle)))
     (vui-fragment
-     ;; Header - plain clickable text (no indent - inherits from parent)
-     ;; The ▶/▼ indicator is baked into the label, so the label changes on
-     ;; every toggle.  Give the button a stable :key (the caller's key, or
-     ;; the title as a fallback) so cursor restoration keeps point on the
-     ;; toggle across expand/collapse instead of losing it when the label
-     ;; flips (see `vui--widget-identity').
-     (vui-button (format "%s %s" indicator title)
-       :no-decoration t
-       :face title-face
-       :help-echo nil
-       :key (or toggle-key title)
-       :on-click (lambda ()
-                   (let ((new-state (not is-expanded)))
-                     (unless is-controlled
-                       (vui-set-state :internal-expanded new-state))
-                     (when on-toggle
-                       (funcall on-toggle new-state)))))
+     header
      ;; Content (indented, only when expanded)
      ;; Use total-indent directly so nested collapsibles render at correct level
      ;; Provide accumulated indent to nested collapsibles via context
@@ -268,6 +290,17 @@ Options:
              Pass an explicit KEY when several collapsibles share a
              title, otherwise their toggles stay ambiguous and cursor
              tracking falls back to position.
+  :header-right VNODE - content shown right-aligned in the header row,
+             opposite the toggle (a count, a badge, a status).  It is
+             header adornment, always visible, distinct from the body
+             children shown only when expanded, and it is presentational
+             (the toggle stays the clickable part).  When set the header
+             becomes a space-between `vui-flex'; when absent the header is
+             just the toggle, unchanged.
+  :header-width WIDTH - width for the header alignment, anything
+             `vui-flex' `:width' accepts (a number, a function, `window',
+             or `fill-column'); defaults to `fill-column'.  Only relevant
+             with :header-right.
 
 Usage:
   (vui-collapsible :title \"Section\" child1 child2)
@@ -281,6 +314,8 @@ Usage:
         (collapsed-indicator nil)
         (indent nil)
         (key nil)
+        (header-right nil)
+        (header-width nil)
         (children nil))
     ;; Parse keyword arguments
     (while (and args (keywordp (car args)))
@@ -293,7 +328,9 @@ Usage:
         (:expanded-indicator (setq expanded-indicator (pop args)))
         (:collapsed-indicator (setq collapsed-indicator (pop args)))
         (:indent (setq indent (pop args)))
-        (:key (setq key (pop args)))))
+        (:key (setq key (pop args)))
+        (:header-right (setq header-right (pop args)))
+        (:header-width (setq header-width (pop args)))))
     ;; Remaining args are children
     (setq children (remq nil (flatten-list args)))
     (vui-component 'vui-collapsible--internal
@@ -310,6 +347,8 @@ Usage:
       ;; inside the component) so its cursor identity survives the label
       ;; flip; this is separate from the reconciliation :key above.
       :toggle-key key
+      :header-right header-right
+      :header-width header-width
       :children children)))
 
 ;;; Semantic Text Faces


### PR DESCRIPTION
`vui-collapsible`'s header was toggle-only: indicator plus title, nothing beside it. So a consumer who wanted something right-aligned next to the toggle (a count, a badge, a status) had to hand-roll their own header, and lost the toggle's cursor identity from #103 in the process. The case I keep hitting is a dashboard section that reads "▶ SchemaName ............ 3 invalid", toggle on the left, count pinned to the window edge.

Two new optional options:

- `:header-right VNODE` puts a vnode right-aligned in the header row opposite the toggle. When set, the header becomes a space-between `vui-flex` (toggle left, adornment right). When absent, the header renders exactly as before, byte for byte, no flex wrapper, so nothing that does not ask for a right side changes.
- `:header-width WIDTH` is the width that alignment targets, anything `vui-flex`'s `:width` accepts (`window`, `fill-column`, a number, a function). Defaults to `fill-column`, matching `vui-flex`'s own default.

The right content is adornment: always visible in the header row (distinct from the body children that hide when collapsed) and presentational (the toggle stays the only clickable part). The toggle keeps its stable `:key` so point rides it across expand and collapse even inside the flex, and a nested collapsible's header subtracts its own indent so the right edge still lands at `:header-width` however deep it sits.

Follow-up to #103.