### PR TITLE
fix: keep point near its row when a re-render removes the widget under it

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,11 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- =vui-goto-key= moves point onto the widget carrying a given reconciliation
+  =:key= (matched with =equal=), returning its position or nil. Handy for
+  steering point to a known row, e.g. parking it on a stable anchor before a
+  refresh so cursor restoration has somewhere to return to.
+
 - =vui-collapsible= takes a rich header. =:header-right= puts a vnode (a
   count, a badge, a status) right-aligned in the header row opposite the
   toggle, and =:header-width= (anything =vui-flex='s =:width= accepts, default
@@ -106,6 +111,17 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- Re-render no longer drops point to the top of the buffer when the row it was
+  on is removed. Cursor restoration first looks for the saved widget by tree
+  path and by =:key=/label; when both miss because the widget is genuinely gone
+  (a list item deleted, a fix that clears its own row), it used to fall through
+  to an ordinal index that overshoots after a deletion and, once that index
+  ran off the end of the now-shorter widget list, gave up at =point-min=. It
+  now follows the successor that slid up into the removed widget's tree path,
+  or, when nothing took that slot (the removed widget was last in its
+  container), lands on the nearest surviving widget by position. So point rides
+  to the next row instead of jumping home. Collapsible dashboards and lists
+  that delete a row under the cursor were the ones feeling this.
 - =vui-collapsible= now keeps point on its header toggle across expand and
   collapse, out of the box. The toggle bakes the ▶/▼ indicator into its
   label, so the label flips on every toggle, and the button carried no

--- a/test/vui-rerender-test.el
+++ b/test/vui-rerender-test.el
@@ -409,6 +409,88 @@
                       :to-equal "target"))
           (kill-buffer "*rr-cr*")))))
 
+  (it "drops point onto the next widget when the one under it is removed"
+    ;; The re-render deletes the row point sits on together with a
+    ;; sibling (a fix that clears a note's last violation takes the whole
+    ;; note), so the saved ordinal index now overshoots the widget list.
+    ;; Point must land on the neighbour that took its place, not at the
+    ;; top of the buffer.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-self-remove ()
+        :state ((show t))
+        :render (apply #'vui-vstack
+                       (append (list (vui-button "head"))
+                               (when show (list (vui-button "t1")
+                                                (vui-button "t2")))
+                               (list (vui-button "tail")))))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-self-remove) "*rr-csr*")))
+        (unwind-protect
+            (with-current-buffer "*rr-csr*"
+              (expect (buffer-string) :to-equal "[head]\n[t1]\n[t2]\n[tail]")
+              ;; Park point on t2 (the second row that will be removed).
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(2)))))
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "t2")
+              (let ((vui--current-instance inst)) (vui-set-state :show nil))
+              (expect (buffer-string) :to-equal "[head]\n[tail]")
+              ;; t1 and t2 are gone; point rides to the row below them.
+              (expect (widget-at (point)) :not :to-be nil)
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "tail"))
+          (kill-buffer "*rr-csr*")))))
+
+  (it "drops point onto the previous widget when the last one is removed"
+    ;; Removing the final widget leaves nothing at or after the saved
+    ;; position, so point falls back to the previous widget.  Two leading
+    ;; rows keep that previous widget (second) distinct from point-min
+    ;; (first), so this fails if point drops to the top instead.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-last-remove ()
+        :state ((show t))
+        :render (vui-vstack
+                  (vui-button "first")
+                  (vui-button "second")
+                  (when show (vui-button "target"))))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-last-remove) "*rr-clr*")))
+        (unwind-protect
+            (with-current-buffer "*rr-clr*"
+              (expect (buffer-string) :to-equal "[first]\n[second]\n[target]")
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(2)))))
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "target")
+              (let ((vui--current-instance inst)) (vui-set-state :show nil))
+              (expect (buffer-string) :to-equal "[first]\n[second]")
+              ;; target was last; point falls back to the previous widget,
+              ;; not to point-min (which would be "first").
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "second"))
+          (kill-buffer "*rr-clr*")))))
+
+  (it "follows to the successor at the same path when a middle widget goes"
+    ;; The removed widget was not last, so a sibling slides up into its
+    ;; tree path and point lands on that successor.  This exercises the
+    ;; `path-widget' branch of restoration; for a single leaf removal it
+    ;; agrees with the position/index fallbacks, so it is coverage of that
+    ;; branch rather than a guard that fails without it (the multi-widget
+    ;; and last-widget removal specs above are the guards).
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-mid-remove ()
+        :state ((show t))
+        :render (vui-vstack
+                  (vui-button "head")
+                  (when show (vui-button "mid"))
+                  (vui-button "tail")))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-mid-remove) "*rr-cmr*")))
+        (unwind-protect
+            (with-current-buffer "*rr-cmr*"
+              (expect (buffer-string) :to-equal "[head]\n[mid]\n[tail]")
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(1)))))
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "mid")
+              (let ((vui--current-instance inst)) (vui-set-state :show nil))
+              (expect (buffer-string) :to-equal "[head]\n[tail]")
+              ;; tail slid into mid's path (1); point follows to it.
+              (expect (widget-get (widget-at (point)) :tag) :to-equal "tail"))
+          (kill-buffer "*rr-cmr*")))))
+
   (it "keeps point on the same field when a row is inserted above it"
     ;; Same shift, but the parked widget is an editable field, so the
     ;; identity comes from its :key rather than a button label.
@@ -546,6 +628,62 @@
               (expect (widget-get (widget-at (point)) :tag)
                       :to-equal "Banana"))
           (kill-buffer "*rr-xk*"))))))
+
+(describe "vui-goto-key"
+  (it "moves point onto the widget carrying KEY and returns its position"
+    (let ((vui-render-delay nil))
+      (vui-defcomponent gk-comp ()
+        :render (vui-vstack
+                  (vui-button "one" :key 'a)
+                  (vui-button "two" :key 'b)
+                  (vui-button "three" :key 'c)))
+      (let ((inst (vui-mount (vui-component 'gk-comp) "*gk*")))
+        (ignore inst)
+        (unwind-protect
+            (with-current-buffer "*gk*"
+              (goto-char (point-min))
+              (let ((pos (vui-goto-key 'b)))
+                (expect pos :to-equal (point))
+                (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'b))
+              ;; Unknown key: point stays put, returns nil.
+              (goto-char (point-max))
+              (let ((before (point)))
+                (expect (vui-goto-key 'missing) :to-be nil)
+                (expect (point) :to-equal before)))
+          (kill-buffer "*gk*")))))
+
+  (it "matches list keys with equal, not eq"
+    (let ((vui-render-delay nil))
+      (vui-defcomponent gk-list ()
+        :render (vui-vstack
+                  (vui-button "x" :key (list 'note "id-1"))
+                  (vui-button "y" :key (list 'note "id-2"))))
+      (let ((inst (vui-mount (vui-component 'gk-list) "*gkl*")))
+        (ignore inst)
+        (unwind-protect
+            (with-current-buffer "*gkl*"
+              (expect (vui-goto-key (list 'note "id-2")) :to-be-truthy)
+              (expect (widget-get (widget-at (point)) :vui-key)
+                      :to-equal (list 'note "id-2")))
+          (kill-buffer "*gkl*")))))
+
+  (it "treats a nil key as a miss, not a match on unkeyed widgets"
+    ;; Unkeyed widgets store a nil :vui-key, so a nil KEY must match none
+    ;; of them rather than jumping to the first.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent gk-nil ()
+        :render (vui-vstack
+                  (vui-button "plain-1")
+                  (vui-button "plain-2")))
+      (let ((inst (vui-mount (vui-component 'gk-nil) "*gkn*")))
+        (ignore inst)
+        (unwind-protect
+            (with-current-buffer "*gkn*"
+              (goto-char (point-max))
+              (let ((before (point)))
+                (expect (vui-goto-key nil) :to-be nil)
+                (expect (point) :to-equal before)))
+          (kill-buffer "*gkn*"))))))
 
 ;;; Viewport stays put when rows shift above point
 

--- a/vui.el
+++ b/vui.el
@@ -2675,11 +2675,13 @@ For editable fields, returns the actual text area, not widget decoration."
 
 (defun vui--save-cursor-position (&optional start end)
   "Save cursor position relative to current widget.
-Returns plist with :path, :index, :identity, :label, :offset for
+Returns plist with :path, :index, :identity, :label, :offset, :pos for
 widgets, or :line, :column for non-widget positions.  :label is the
 widget's `:tag', kept alongside :identity so a key shared across the
 buffer can be disambiguated on restore (see
-`vui--find-widget-by-identity').
+`vui--find-widget-by-identity').  :pos is the absolute buffer position,
+used to land on the nearest surviving widget when the saved one is gone
+\(see `vui--restore-cursor-position').
 When START and END are given, widget indexing is scoped to that
 region (used by inline instances, which only manage a region)."
   (let ((widget (widget-at (point)))
@@ -2693,7 +2695,7 @@ region (used by inline instances, which only manage a region)."
                (identity (vui--widget-identity widget))
                (label (widget-get widget :tag)))
           (list :path path :index index :identity identity
-                :label label :offset offset))
+                :label label :offset offset :pos pos))
       ;; No widget at point - save line/column as fallback
       (list :line (line-number-at-pos) :column (current-column)))))
 
@@ -2802,6 +2804,21 @@ Point is clamped to WIDGET's bounds; a nil OFFSET counts as 0."
                       (min (+ widget-start (or offset 0))
                            (1- widget-end)))))))
 
+(defun vui--nearest-widget (pos &optional start end)
+  "Return the collected widget nearest buffer position POS, or nil.
+Widgets are scanned in buffer order: the first one starting at or after
+POS wins, otherwise the last one before POS.  Used by
+`vui--restore-cursor-position' to drop point onto a neighbour when the
+widget it was on has been removed.  Bounds default to the whole buffer."
+  (let ((prev nil))
+    (catch 'found
+      (dolist (widget (vui--collect-widgets start end))
+        (let ((wstart (car (vui--widget-bounds widget))))
+          (cond ((null wstart) nil)
+                ((>= wstart pos) (throw 'found widget))
+                (t (setq prev widget)))))
+      prev)))
+
 (defun vui--restore-cursor-position (cursor-info &optional start end)
   "Restore cursor from CURSOR-INFO saved by `vui--save-cursor-position'.
 When START and END are given, widget lookups are scoped to that
@@ -2813,6 +2830,7 @@ region and fallbacks move to START instead of the buffer beginning."
          (label (plist-get cursor-info :label))
          (line (plist-get cursor-info :line))
          (column (plist-get cursor-info :column))
+         (pos (plist-get cursor-info :pos))
          (home (or start (point-min)))
          ;; Single lookup for path-based matching
          (path-widget (and path (vui--find-widget-by-path path start end)))
@@ -2839,20 +2857,56 @@ region and fallbacks move to START instead of the buffer beginning."
      ;; Path drifted: relocate the same widget by stable identity
      (identity-widget
       (vui--goto-widget-offset identity-widget offset))
-     ;; Fall back to index-based matching
-     (index
-      (let ((widget (nth index (vui--collect-widgets start end))))
-        (if widget
-            (vui--goto-widget-offset widget offset)
-          (goto-char home))))
-     ;; Fall back to line/column for non-widget positions
-     ((and line column)
-      (goto-char (point-min))
-      (forward-line (1- line))
-      (move-to-column column))
-     ;; Last resort
+     ;; The saved widget is gone (identity found nothing).  The widget now
+     ;; occupying its tree path is the successor that slid up into the
+     ;; vacated slot, so point follows to the next row.  PATH-OK already
+     ;; rejected this widget when the saved one had merely SURVIVED and a
+     ;; neighbour slid over it, so reaching here means it is truly gone.
+     (path-widget
+      (vui--goto-widget-offset path-widget 0))
      (t
-      (goto-char home)))))
+      ;; Nothing occupies that path either (the removed widget was last in
+      ;; its container), so land on the nearest surviving widget to where
+      ;; point was, rather than jumping to the top of the buffer.
+      (let ((near (and pos (vui--nearest-widget pos start end))))
+        (cond
+         (near
+          (vui--goto-widget-offset near 0))
+         ;; Fall back to index-based matching
+         (index
+          (let ((widget (nth index (vui--collect-widgets start end))))
+            (if widget
+                (vui--goto-widget-offset widget offset)
+              (goto-char home))))
+         ;; Fall back to line/column for non-widget positions
+         ((and line column)
+          (goto-char (point-min))
+          (forward-line (1- line))
+          (move-to-column column))
+         ;; Last resort
+         (t
+          (goto-char home))))))))
+
+(defun vui-goto-key (key &optional start end)
+  "Move point onto the widget whose reconciliation `:key' is KEY.
+Search the widgets between START and END (default: the whole buffer) in
+the current buffer, comparing keys with `equal'.  On a match, move point
+\(and the point of every window showing the buffer) to the widget's
+start and return that position; return nil when no widget carries KEY.
+
+Handy for steering point to a known row after a re-render, e.g. before
+refreshing so cursor restoration has a stable anchor to return to.  A nil
+KEY matches nothing and returns nil: unkeyed widgets carry a nil
+`:vui-key', so treating nil as a wildcard would jump to the first of
+them."
+  (when-let* ((widget (and key
+                           (seq-find (lambda (w) (equal (widget-get w :vui-key) key))
+                                     (vui--collect-widgets start end))))
+              (pos (car (vui--widget-bounds widget))))
+    (goto-char pos)
+    (dolist (win (get-buffer-window-list (current-buffer) nil t))
+      (set-window-point win pos))
+    pos))
 
 (defun vui--remove-widget-overlays (&optional start end)
   "Remove widget-related overlays between START and END.


### PR DESCRIPTION
Re-render used to drop point to the top of the buffer when the row it was on got removed (a list item deleted, a fix that clears its own row). Cursor restoration matched the saved widget by tree path and by `:key`/label; when both missed because the widget was genuinely gone, it fell through to an ordinal index that overshoots after a deletion and, once that index ran off the end of the now-shorter widget list, gave up at `point-min`.

Now, once the saved widget is gone, restoration follows the successor that slid up into its tree path, so a middle deletion drops point onto the next row. When nothing took that slot (the removed widget was last in its container), it lands on the nearest surviving widget by the saved position. Either way point rides to a neighbour instead of jumping home.

Also adds `vui-goto-key`, a small public helper that moves point onto the widget carrying a given `:key` (matched with `equal`, returns its position or nil), handy for parking point on a stable anchor before a refresh.

Motivation: collapsible dashboards and lists (the vulpea-ui schema dashboard is what turned this up) lose the cursor when an item vanishes under it, and the same shows up in the sidebar. Fixing it here helps every vui app rather than each one reaching for its own workaround.

637 specs green; compile (warnings-as-errors) and lint clean.
