### PR TITLE
fix: recover cursor to the nearest tree neighbour when its row is removed

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -111,17 +111,18 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
-- Re-render no longer drops point to the top of the buffer when the row it was
-  on is removed. Cursor restoration first looks for the saved widget by tree
-  path and by =:key=/label; when both miss because the widget is genuinely gone
-  (a list item deleted, a fix that clears its own row), it used to fall through
-  to an ordinal index that overshoots after a deletion and, once that index
-  ran off the end of the now-shorter widget list, gave up at =point-min=. It
-  now follows the successor that slid up into the removed widget's tree path,
-  or, when nothing took that slot (the removed widget was last in its
-  container), lands on the nearest surviving widget by position. So point rides
-  to the next row instead of jumping home. Collapsible dashboards and lists
-  that delete a row under the cursor were the ones feeling this.
+- Re-render recovers point semantically when the row it was on is removed,
+  instead of dropping to the top of the buffer. Cursor restoration first looks
+  for the saved widget by tree path and by =:key=/label; when both miss because
+  the widget is genuinely gone (a list item deleted, a fix that clears its own
+  row), it recovers to the surviving widget nearest it in the component tree,
+  not by raw buffer position: the sibling that slid into its slot, the previous
+  sibling when it was the last one in its container, or an ancestor. Nearness
+  is a longer shared =:vui-path= prefix first (so recovery stays inside the same
+  container), then the nearest sibling at the first differing step. So point
+  keeps to a related row in the same container rather than jumping home or
+  drifting across a boundary into an unrelated group, and every collapsible
+  dashboard or list gets this without hand-rolling it.
 - =vui-collapsible= now keeps point on its header toggle across expand and
   collapse, out of the box. The toggle bakes the ▶/▼ indicator into its
   label, so the label flips on every toggle, and the button carried no

--- a/test/vui-rerender-test.el
+++ b/test/vui-rerender-test.el
@@ -466,11 +466,8 @@
 
   (it "follows to the successor at the same path when a middle widget goes"
     ;; The removed widget was not last, so a sibling slides up into its
-    ;; tree path and point lands on that successor.  This exercises the
-    ;; `path-widget' branch of restoration; for a single leaf removal it
-    ;; agrees with the position/index fallbacks, so it is coverage of that
-    ;; branch rather than a guard that fails without it (the multi-widget
-    ;; and last-widget removal specs above are the guards).
+    ;; tree path.  That sibling now shares the full path with the removed
+    ;; one, so tree-nearest recovery lands point on it.
     (let ((vui-render-delay nil))
       (vui-defcomponent rr-cursor-mid-remove ()
         :state ((show t))
@@ -490,6 +487,37 @@
               ;; tail slid into mid's path (1); point follows to it.
               (expect (widget-get (widget-at (point)) :tag) :to-equal "tail"))
           (kill-buffer "*rr-cmr*")))))
+
+  (it "recovers within the same container, not across a boundary by position"
+    ;; Two sibling groups.  Point is on the last leaf of the first group;
+    ;; removing it, the first leaf of the SECOND group slides up into that
+    ;; buffer line, so a position-based recovery would jump there.  The
+    ;; tree keeps point on the previous leaf of the SAME group, because it
+    ;; shares a longer path prefix.  This is the case a flat buffer-nearest
+    ;; fallback gets wrong.
+    (let ((vui-render-delay nil))
+      (vui-defcomponent rr-cursor-container ()
+        :state ((show t))
+        :render (vui-vstack
+                  (vui-vstack
+                    (vui-button "a1" :key 'a1)
+                    (when show (vui-button "a2" :key 'a2)))
+                  (vui-vstack
+                    (vui-button "b1" :key 'b1)
+                    (vui-button "b2" :key 'b2))))
+      (let ((inst (vui-mount (vui-component 'rr-cursor-container) "*rr-cont*")))
+        (unwind-protect
+            (with-current-buffer "*rr-cont*"
+              (expect (buffer-string) :to-equal "[a1]\n[a2]\n[b1]\n[b2]")
+              ;; Park on a2, the last leaf of the first group (path (0 1)).
+              (goto-char (car (vui--widget-bounds
+                               (vui--find-widget-by-path '(0 1)))))
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'a2)
+              (let ((vui--current-instance inst)) (vui-set-state :show nil))
+              (expect (buffer-string) :to-equal "[a1]\n[b1]\n[b2]")
+              ;; a2 gone; point stays on a1 (same group), not b1 (next group).
+              (expect (widget-get (widget-at (point)) :vui-key) :to-equal 'a1))
+          (kill-buffer "*rr-cont*")))))
 
   (it "keeps point on the same field when a row is inserted above it"
     ;; Same shift, but the parked widget is an editable field, so the

--- a/vui.el
+++ b/vui.el
@@ -2675,41 +2675,26 @@ For editable fields, returns the actual text area, not widget decoration."
 
 (defun vui--save-cursor-position (&optional start end)
   "Save cursor position relative to current widget.
-Returns plist with :path, :index, :identity, :label, :offset, :pos for
-widgets, or :line, :column for non-widget positions.  :label is the
-widget's `:tag', kept alongside :identity so a key shared across the
-buffer can be disambiguated on restore (see
-`vui--find-widget-by-identity').  :pos is the absolute buffer position,
-used to land on the nearest surviving widget when the saved one is gone
-\(see `vui--restore-cursor-position').
-When START and END are given, widget indexing is scoped to that
-region (used by inline instances, which only manage a region)."
-  (let ((widget (widget-at (point)))
-        (pos (point)))
+Returns plist with :path, :identity, :label, :offset for widgets, or
+:line, :column for non-widget positions.  :path is the widget's ordinal
+tree path, used to relocate it (or, when it is gone, its nearest tree
+neighbour) on restore.  :label is the widget's `:tag', kept alongside
+:identity so a key shared across the buffer can be disambiguated on
+restore (see `vui--find-widget-by-identity').
+START and END are accepted for symmetry with `vui--restore-cursor-position'
+but are not needed here."
+  (ignore start end)
+  (let ((widget (widget-at (point))))
     (if widget
         (let* ((bounds (vui--widget-bounds widget))
                (widget-start (car bounds))
-               (offset (if widget-start (- pos widget-start) 0))
+               (offset (if widget-start (- (point) widget-start) 0))
                (path (widget-get widget :vui-path))
-               (index (vui--widget-index widget start end))
                (identity (vui--widget-identity widget))
                (label (widget-get widget :tag)))
-          (list :path path :index index :identity identity
-                :label label :offset offset :pos pos))
+          (list :path path :identity identity :label label :offset offset))
       ;; No widget at point - save line/column as fallback
       (list :line (line-number-at-pos) :column (current-column)))))
-
-(defun vui--widget-index (widget &optional start end)
-  "Get index of WIDGET among the widgets between START and END.
-Bounds default to the whole buffer."
-  (let ((widgets (vui--collect-widgets start end))
-        (idx 0))
-    (catch 'found
-      (dolist (w widgets)
-        (when (eq w widget)
-          (throw 'found idx))
-        (setq idx (1+ idx)))
-      nil)))
 
 (defun vui--collect-widgets (&optional start end)
   "Collect widgets between START and END in order of appearance.
@@ -2804,33 +2789,54 @@ Point is clamped to WIDGET's bounds; a nil OFFSET counts as 0."
                       (min (+ widget-start (or offset 0))
                            (1- widget-end)))))))
 
-(defun vui--nearest-widget (pos &optional start end)
-  "Return the collected widget nearest buffer position POS, or nil.
-Widgets are scanned in buffer order: the first one starting at or after
-POS wins, otherwise the last one before POS.  Used by
-`vui--restore-cursor-position' to drop point onto a neighbour when the
-widget it was on has been removed.  Bounds default to the whole buffer."
-  (let ((prev nil))
-    (catch 'found
-      (dolist (widget (vui--collect-widgets start end))
-        (let ((wstart (car (vui--widget-bounds widget))))
-          (cond ((null wstart) nil)
-                ((>= wstart pos) (throw 'found widget))
-                (t (setq prev widget)))))
-      prev)))
+(defun vui--path-lt (a b)
+  "Non-nil when numeric key list A sorts before B lexicographically.
+A and B are the comparison keys built by `vui--path-nearest-widget'."
+  (catch 'done
+    (while (and a b)
+      (cond ((< (car a) (car b)) (throw 'done t))
+            ((> (car a) (car b)) (throw 'done nil)))
+      (setq a (cdr a) b (cdr b)))
+    nil))
+
+(defun vui--path-nearest-widget (path &optional start end)
+  "Return the surviving widget whose `:vui-path' is nearest PATH, or nil.
+Nearness is measured in the component tree, not by buffer position: a
+widget sharing a longer path prefix with PATH wins (so recovery stays
+inside the same container), and among those the one nearest at the first
+differing step wins, the successor that slid up into the vacated slot
+before the predecessor.  So when the widget PATH pointed at is removed,
+point recovers to a sibling of the removed node, or failing that to an
+ancestor, rather than to whatever merely sits nearby in the buffer.
+Bounds default to the whole buffer."
+  (let ((best nil) (best-key nil))
+    (dolist (widget (vui--collect-widgets start end) best)
+      (when-let* ((q (widget-get widget :vui-path)))
+        (let* ((shared (let ((n 0) (a path) (b q))
+                         (while (and a b (equal (car a) (car b)))
+                           (setq n (1+ n) a (cdr a) b (cdr b)))
+                         n))
+               (pe (nth shared path))
+               (qe (nth shared q))
+               ;; Smaller key = nearer.  Order the tuple so the tree
+               ;; semantics fall out of a plain lexicographic compare.
+               (key (list (- shared)                        ; longer prefix first
+                          (if (and pe qe) (abs (- pe qe)) 0) ; nearer sibling first
+                          (if (and pe qe (> qe pe)) 0 1)     ; successor before predecessor
+                          (length q))))                      ; shallower (nearer parent) first
+          (when (or (null best-key) (vui--path-lt key best-key))
+            (setq best widget best-key key)))))))
 
 (defun vui--restore-cursor-position (cursor-info &optional start end)
   "Restore cursor from CURSOR-INFO saved by `vui--save-cursor-position'.
 When START and END are given, widget lookups are scoped to that
 region and fallbacks move to START instead of the buffer beginning."
   (let* ((path (plist-get cursor-info :path))
-         (index (plist-get cursor-info :index))
          (offset (plist-get cursor-info :offset))
          (identity (plist-get cursor-info :identity))
          (label (plist-get cursor-info :label))
          (line (plist-get cursor-info :line))
          (column (plist-get cursor-info :column))
-         (pos (plist-get cursor-info :pos))
          (home (or start (point-min)))
          ;; Single lookup for path-based matching
          (path-widget (and path (vui--find-widget-by-path path start end)))
@@ -2857,33 +2863,21 @@ region and fallbacks move to START instead of the buffer beginning."
      ;; Path drifted: relocate the same widget by stable identity
      (identity-widget
       (vui--goto-widget-offset identity-widget offset))
-     ;; The saved widget is gone (identity found nothing).  The widget now
-     ;; occupying its tree path is the successor that slid up into the
-     ;; vacated slot, so point follows to the next row.  PATH-OK already
-     ;; rejected this widget when the saved one had merely SURVIVED and a
-     ;; neighbour slid over it, so reaching here means it is truly gone.
-     (path-widget
-      (vui--goto-widget-offset path-widget 0))
      (t
-      ;; Nothing occupies that path either (the removed widget was last in
-      ;; its container), so land on the nearest surviving widget to where
-      ;; point was, rather than jumping to the top of the buffer.
-      (let ((near (and pos (vui--nearest-widget pos start end))))
+      ;; The saved widget is gone.  Recover to the surviving widget nearest
+      ;; it in the component tree (`vui--path-nearest-widget'): the sibling
+      ;; that slid into its slot, the previous sibling when it was last in
+      ;; its container, or an ancestor, rather than whatever merely sits
+      ;; nearby in the buffer.  Falls back to line/column for a saved
+      ;; non-widget position, then to HOME.
+      (let ((near (and path (vui--path-nearest-widget path start end))))
         (cond
          (near
           (vui--goto-widget-offset near 0))
-         ;; Fall back to index-based matching
-         (index
-          (let ((widget (nth index (vui--collect-widgets start end))))
-            (if widget
-                (vui--goto-widget-offset widget offset)
-              (goto-char home))))
-         ;; Fall back to line/column for non-widget positions
          ((and line column)
           (goto-char (point-min))
           (forward-line (1- line))
           (move-to-column column))
-         ;; Last resort
          (t
           (goto-char home))))))))
 


### PR DESCRIPTION
Follow-up to #105. When a re-render removes the widget point was on, restoration now recovers to the surviving widget nearest it in the **component tree** rather than by raw buffer position.

#105 fixed the point-min jump, but its last-resort fallback was buffer-position "nearest widget", which is the wrong metric: it doesn't know about containers, so removing a section's last row could drop point onto the *next section* (or overshoot it) instead of the previous row in the same section. `:vui-path` already encodes the tree, so the fix is to measure nearness there.

Nearness: longer shared `:vui-path` prefix first (stay in the same container), then nearest sibling at the first differing step, successor before predecessor. That single rule gives:
- middle removal -> the sibling that slid into the slot (subsumes #105's `path-widget` step),
- last-in-container removal -> the previous sibling (in the same container),
- only child removed -> an ancestor,

all without leaving the container. The dashboard case that motivated this (fix a schema's last invalid note, want point on the previous note, not the next schema two rows down) now works generically, so `vulpea-ui`'s hand-rolled anchor logic can go away.

New spec `recovers within the same container, not across a boundary by position` is the guard that a flat buffer-nearest fallback fails; the existing removal specs still pass. Also drops the now-dead `:pos`/`:index` cursor-info keys, `vui--widget-index`, and `vui--nearest-widget`.

639 specs green; compile (warnings-as-errors) and lint clean.
