### PR TITLE
perf: render buttons in linear time (fixes #107)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -111,6 +111,19 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- Rendering many buttons (or checkboxes and selects) is linear again, not
+  O(n^2). Every widget =widget-create= builds leaves two live markers behind
+  (its =:from=/=:to= bounds), and Emacs adjusts every live marker on every
+  insert, so a buffer of N widgets cost O(N^2) to build: a ~6000-row schema
+  dashboard took ~8.5s, and a 100k-row one crashed Emacs outright (#107). Plain
+  text and flex layout stayed linear because overlays (Emacs 29+) carry no such
+  cost, only explicit markers do. vui now detaches those bounds markers right
+  after creating each button, checkbox and select, and reads their bounds from
+  the button overlay instead (which tracks position for free), so navigation and
+  cursor tracking are unchanged. That same 6000-row dashboard now builds in
+  ~0.1s, and buttons render at a flat ~8us/row through 16000. Editable fields
+  keep their markers: they rely on their own field machinery and are never
+  numerous enough to matter.
 - Re-render recovers point semantically when the row it was on is removed,
   instead of dropping to the top of the buffer. Cursor restoration first looks
   for the saved widget by tree path and by =:key=/label; when both miss because

--- a/benchmarks/README.org
+++ b/benchmarks/README.org
@@ -42,10 +42,16 @@ shape, not absolute milliseconds (which depend on the machine):
   transcript is O(M^2) overall. This is the case where a marker-based
   append (insert at the end, no full rebuild) wins, and the main
   motivation for incremental rendering (#82).
-- *Widgets are the steepest cliff.* Interactive widgets (buttons,
-  fields) are markedly more expensive than text and scale worse than
-  linearly, because each one is created through =widget.el= on every
-  render. Widget-heavy re-renders are where vui slows down first.
+- *Widgets cost more than text, but scale linearly.* Interactive widgets
+  (buttons, checkboxes, selects) are several times more expensive per row
+  than plain text, because each one is created through =widget.el= on every
+  render. They used to scale *worse* than linearly: =widget-create= leaves
+  two live markers per widget, and Emacs adjusts every live marker on every
+  insert, so N buttons cost O(N^2) to build and tens of thousands could
+  crash Emacs (#107). vui now detaches those markers right after creating
+  each widget and reads bounds from the button overlay, so button-heavy
+  renders are linear again (a flat ~8us/row in batch). Editable fields keep
+  their markers, but you rarely have many at once.
 
 Re-run after performance changes and compare; the suite exists so those
 changes can be justified and regressions caught.

--- a/test/vui-widget-markers-test.el
+++ b/test/vui-widget-markers-test.el
@@ -1,0 +1,97 @@
+;;; vui-widget-markers-test.el --- Widget marker tests for vui.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; Regression tests for issue #107: rendering many widget buttons was
+;; O(n^2) because each `widget-create' push-button leaves two live
+;; markers (:from/:to) in the buffer, and Emacs adjusts every live
+;; marker on every subsequent insert.  vui detaches those markers right
+;; after creating each non-field widget and reads bounds from the button
+;; overlay instead, keeping renders linear without losing cursor
+;; tracking.  These tests lock in that invariant.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+(describe "widget bounds markers (issue #107)"
+  (it "leaves no live :from/:to markers on a rendered button"
+    ;; The anti-quadratic invariant: a button must not keep markers alive
+    ;; in the buffer, or every later insert pays to adjust them.
+    (with-temp-buffer
+      (vui-render (vui-button "click" :on-click #'ignore) (current-buffer))
+      (goto-char (point-min))
+      (let* ((w (widget-at (point)))
+             (from (widget-get w :from))
+             (to (widget-get w :to)))
+        (expect w :to-be-truthy)
+        ;; Detached markers point nowhere: no buffer, no position.
+        (expect (and (markerp from) (marker-buffer from)) :to-be nil)
+        (expect (and (markerp to) (marker-buffer to)) :to-be nil))))
+
+  (it "leaves no live :from/:to markers on a rendered checkbox"
+    (with-temp-buffer
+      (vui-render (vui-checkbox :checked t :on-change #'ignore) (current-buffer))
+      (goto-char (point-min))
+      (let* ((w (widget-at (point)))
+             (from (widget-get w :from))
+             (to (widget-get w :to)))
+        (expect w :to-be-truthy)
+        (expect (and (markerp from) (marker-buffer from)) :to-be nil)
+        (expect (and (markerp to) (marker-buffer to)) :to-be nil))))
+
+  (it "still reports correct bounds for a button after detaching markers"
+    ;; Bounds must survive via the button overlay so cursor tracking keeps
+    ;; working (see `vui--widget-bounds').
+    (with-temp-buffer
+      (vui-render (vui-button "hello" :on-click #'ignore) (current-buffer))
+      (goto-char (point-min))
+      (let* ((w (widget-at (point)))
+             (bounds (vui--widget-bounds w)))
+        (expect bounds :to-be-truthy)
+        (expect (car bounds) :to-equal (point-min))
+        (expect (< (car bounds) (cdr bounds)) :to-be-truthy)
+        (expect (buffer-substring-no-properties (car bounds) (cdr bounds))
+                :to-equal "[hello]"))))
+
+  (it "keeps widget navigation working after detaching markers"
+    ;; Navigation keys off the button overlay, not :from/:to, so TAB must
+    ;; still land on buttons.
+    (with-temp-buffer
+      (vui-render (vui-vstack (vui-button "one" :on-click #'ignore)
+                              (vui-button "two" :on-click #'ignore))
+                  (current-buffer))
+      (goto-char (point-min))
+      (widget-forward 1)
+      (expect (widget-at (point)) :to-be-truthy)
+      (let ((tags (list (widget-get (widget-at (point)) :tag))))
+        (widget-forward 1)
+        (push (widget-get (widget-at (point)) :tag) tags)
+        ;; Both buttons are reachable via navigation.
+        (expect (sort (copy-sequence tags) #'string<)
+                :to-equal '("one" "two")))))
+
+  (it "does not grow live markers as button count grows"
+    ;; Guards the O(n^2) regression at the mechanism level: N buttons must
+    ;; not leave ~2N live markers behind.  We count markers by probing each
+    ;; button's :from/:to, which the fix detaches.
+    (with-temp-buffer
+      (vui-render (apply #'vui-vstack
+                         (mapcar (lambda (i)
+                                   (vui-button (format "b%d" i)
+                                               :on-click #'ignore))
+                                 (number-sequence 1 20)))
+                  (current-buffer))
+      (let ((live 0))
+        (dolist (ov (overlays-in (point-min) (point-max)))
+          (when-let* ((w (overlay-get ov 'button))
+                      (from (widget-get w :from)))
+            (when (and (markerp from) (marker-buffer from))
+              (setq live (1+ live)))))
+        (expect live :to-equal 0)))))
+
+(provide 'vui-widget-markers-test)
+;;; vui-widget-markers-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -2658,20 +2658,47 @@ BUFFER defaults to the current buffer.  Undoes
     (remove-hook 'window-size-change-functions
                  #'vui--on-window-size-change t)))
 
+(defun vui--detach-widget-bounds-markers (widget)
+  "Detach WIDGET's :from/:to bounds markers from the buffer.
+
+`widget-create' leaves two live markers per widget (its :from/:to
+bounds).  Emacs adjusts every live marker on each insert, so a buffer of
+N such widgets makes rendering O(N^2) and, at tens of thousands of
+widgets, can crash Emacs (issue #107).  Buttons, checkboxes and selects
+do not need those markers after creation - their bounds are recoverable
+from the button overlay (see `vui--widget-bounds') - so detaching them
+keeps rendering linear.  Editable fields are left untouched: they rely on
+their own field overlay and are never numerous enough to matter."
+  (let ((from (widget-get widget :from))
+        (to (widget-get widget :to)))
+    (when (markerp from) (set-marker from nil))
+    (when (markerp to) (set-marker to nil))))
+
 (defun vui--widget-bounds (widget)
   "Get (START . END) bounds for WIDGET's editable area.
-For editable fields, returns the actual text area, not widget decoration."
+For editable fields, returns the actual text area, not widget
+decoration.  For buttons and other overlay-based widgets, reads the
+button overlay, whose bounds survive `vui--detach-widget-bounds-markers'
+\(issue #107); falls back to the :from/:to markers when no overlay is
+present."
   (let ((field-start (widget-field-start widget))
         (field-end (widget-field-end widget)))
     (if (and field-start field-end)
         ;; Editable field - use field bounds
         (cons field-start field-end)
-      ;; Other widgets - use widget bounds
-      (let ((from (widget-get widget :from))
-            (to (widget-get widget :to)))
-        (when (and from to)
-          (cons (if (markerp from) (marker-position from) from)
-                (if (markerp to) (marker-position to) to)))))))
+      (let ((overlay (widget-get widget :button-overlay)))
+        (if (and (overlayp overlay) (overlay-buffer overlay))
+            ;; Button/checkbox/select - overlay tracks bounds without the
+            ;; per-insert marker cost the :from/:to markers would add
+            (cons (overlay-start overlay) (overlay-end overlay))
+          ;; Fallback - widget bounds via :from/:to (markers or ints)
+          (let ((from (widget-get widget :from))
+                (to (widget-get widget :to)))
+            (when (and from to)
+              (let ((fp (if (markerp from) (marker-position from) from))
+                    (tp (if (markerp to) (marker-position to) to)))
+                (when (and fp tp)
+                  (cons fp tp))))))))))
 
 (defun vui--save-cursor-position (&optional start end)
   "Save cursor position relative to current widget.
@@ -4862,7 +4889,10 @@ wholesale render's empty-child handling)."
         ;; Store reconciliation key so cursor identity can tell
         ;; same-label buttons apart (see `vui--widget-identity')
         (when-let* ((key (vui-vnode-button-key vnode)))
-          (widget-put w :vui-key key)))))
+          (widget-put w :vui-key key))
+        ;; Detach :from/:to bounds markers so later inserts stay O(1)
+        ;; (see issue #107); bounds come from the button overlay
+        (vui--detach-widget-bounds-markers w))))
 
    ;; Checkbox
    ((vui-vnode-checkbox-p vnode)
@@ -4887,7 +4917,9 @@ wholesale render's empty-child handling)."
         ;; A checkbox has no label, so its :key is its only stable
         ;; cursor identity (see `vui--widget-identity')
         (when-let* ((key (vui-vnode-checkbox-key vnode)))
-          (widget-put w :vui-key key)))
+          (widget-put w :vui-key key))
+        ;; Detach :from/:to bounds markers (see issue #107)
+        (vui--detach-widget-bounds-markers w))
       (when label
         (insert " " label))))
 
@@ -4934,7 +4966,9 @@ wholesale render's empty-child handling)."
         ;; button label reflects the current selection (see
         ;; `vui--widget-identity')
         (when-let* ((key (vui-vnode-select-key vnode)))
-          (widget-put w :vui-key key)))))
+          (widget-put w :vui-key key))
+        ;; Detach :from/:to bounds markers (see issue #107)
+        (vui--detach-widget-bounds-markers w))))
 
    ;; Horizontal stack
    ;; Children that render to nothing (e.g., components returning nil)


### PR DESCRIPTION
Buttons rendered in O(n^2). Turns out it is not schema-specific or even vui's fault really: every push-button that widget.el creates leaves two live markers behind (its :from/:to bounds), and Emacs re-adjusts every live marker on every insert. So a buffer with N buttons costs O(N^2) to build. The ~6000-row dashboard from #107 took ~8.5s, and a 100k-row one crashed Emacs.

Plain text and flex layout stayed linear the whole time because overlays (Emacs 29+) do not have this cost, only explicit markers do. That was the tell: the two markers per widget are the entire problem.

The fix is small: detach those :from/:to markers right after creating each button, checkbox and select, and read their bounds from the button overlay instead (it tracks position for free and survives the detach). Navigation and cursor tracking already key off the overlay, not those markers, so behavior is unchanged. Editable fields keep their markers since they need their own machinery and you never have thousands of them.

Numbers (batch): the 6000-row dashboard goes from ~8.5s to ~0.1s, and single buttons render at a flat ~8us/row through 16000 rows (was rising: 41 -> 61 -> 84 -> 142 -> 271 us/row). Linear now, so the 100k dashboard renders instead of crashing.

Follow-up worth having: reassess whether we even need widget.el for buttons at all. button.el text buttons are another ~4x cheaper (~2us/row) and carry no markers, but they are not widgets, so TAB/S-TAB navigation and cursor tracking would need reworking. Left out of scope here.

Closes #107.