### PR TITLE
fix: clear stale field state before vui-render erases the buffer

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -111,6 +111,16 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- Calling the low-level =vui-render= twice on the same buffer no longer crashes
+  when that buffer holds a =vui-field=. The first render leaves the field's
+  =widget-after-change= hook on =after-change-functions= and the field itself in
+  =widget-field-list=; the second render's =erase-buffer= then fired that hook
+  against the just-deleted field and signalled =(number-or-marker-p nil)=. It
+  was pre-existing and specific to reusing =vui-render= directly - =vui-mount='s
+  re-render path and fresh =with-temp-buffer= renders were fine, because the
+  component re-render path already clears the field lists before erasing.
+  =vui-render= now does the same, which also stops dead field widgets from
+  piling up in =widget-field-list= across renders.
 - Rendering many buttons (or checkboxes and selects) is linear again, not
   O(n^2). Every widget =widget-create= builds leaves two live markers behind
   (its =:from=/=:to= bounds), and Emacs adjusts every live marker on every

--- a/test/vui-test.el
+++ b/test/vui-test.el
@@ -359,6 +359,31 @@ Buttons are widget.el push-buttons, so we use widget-apply."
             (expect (vui-field-value 'second-key) :to-equal "second"))
         (kill-buffer "*test-fv4*")))))
 
+(describe "vui-render re-render on the same buffer"
+  ;; Regression: calling the low-level `vui-render' twice on the same
+  ;; buffer used to signal (number-or-marker-p nil) during the second
+  ;; render's `erase-buffer'.  A `vui-field' installs
+  ;; `widget-after-change' on `after-change-functions' and leaves the
+  ;; field in `widget-field-list'; erasing then fired that hook against
+  ;; the just-deleted field.  `vui-render' now drops the field
+  ;; bookkeeping before erasing, like the component re-render path.
+  (it "re-renders a field on the same buffer without error"
+    (with-temp-buffer
+      (vui-render (vui-field :size 10 :key 'f :value "hello"))
+      (expect (vui-render (vui-field :size 10 :key 'f :value "world"))
+              :not :to-throw)
+      (expect (vui-field-value 'f) :to-equal "world")))
+
+  (it "does not accumulate stale fields across renders"
+    (with-temp-buffer
+      (vui-render (vui-field :size 10 :key 'f :value "one"))
+      (vui-render (vui-field :size 10 :key 'f :value "two"))
+      (vui-render (vui-field :size 10 :key 'f :value "three"))
+      ;; Each render clears the previous field, so only the current one
+      ;; survives -- no dead widgets pile up in `widget-field-list'.
+      (expect (length widget-field-list) :to-equal 1)
+      (expect (vui-field-value 'f) :to-equal "three"))))
+
 
 (describe "vui-checkbox"
   (it "creates a checkbox vnode"

--- a/vui.el
+++ b/vui.el
@@ -5374,6 +5374,14 @@ Clears the buffer before rendering."
       ;; Enable vui-mode (this also sets up the keymap hierarchy)
       (unless (derived-mode-p 'vui-mode)
         (vui-mode))
+      ;; Drop stale field bookkeeping before erasing.  A `vui-field'
+      ;; from a previous render installs `widget-after-change' on
+      ;; `after-change-functions' and lingers in `widget-field-list';
+      ;; the `erase-buffer' below would otherwise fire that hook against
+      ;; the just-deleted field and signal (number-or-marker-p nil).
+      ;; Clearing the lists (as the component re-render path does) also
+      ;; keeps dead widgets from piling up across renders.
+      (setq widget-field-list nil widget-field-new nil)
       (remove-overlays)
       (erase-buffer)
       (vui--render-vnode vnode)


### PR DESCRIPTION
Calling the low-level `vui-render` twice on the same buffer that has a `vui-field` in it used to blow up with `(number-or-marker-p nil)` on the second render's `erase-buffer`.

The field leaves `widget-after-change` on `after-change-functions` and sticks around in `widget-field-list`, so erasing fires that hook against a field whose text is already gone. It's pre-existing (reproduces on master) and specific to reusing `vui-render` directly - `vui-mount` re-renders and fresh `with-temp-buffer` renders were always fine, because the component re-render path already clears the field lists before erasing.

So `vui-render` now does the same: drop `widget-field-list`/`widget-field-new` before the erase. As a bonus this also stops dead field widgets from piling up in `widget-field-list` across renders, which the alternative (just binding `inhibit-modification-hooks`) wouldn't.

Same root cause as the `vui-unmount` fix, whose comment even says "the render path inhibits these hooks for the same reason" - turns out the low-level render path was the one spot that still didn't.