### PR TITLE
fix: treat only one-arg callables as functional state updates

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -111,6 +111,15 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-set-state= no longer mistakes a data symbol that happens to be a
+  function for a functional update. It ran VALUE on the current state whenever
+  =(functionp value)= was non-nil, but Emacs 31 made =all= a builtin, so
+  =(vui-set-state :filter 'all)= called =(all old-value)= and signalled
+  =(wrong-number-of-arguments ...)=. A value is now treated as an updater only
+  when it can accept one argument, so a data symbol like =all= (or =cons=) is
+  stored literally, while =#'1+= and =(lambda (old) ...)= still update as
+  before. This bit any =vui-set-state= whose value was a bare symbol that was
+  =fboundp= (the todo example's =all=/=active=/=completed= filters).
 - Calling the low-level =vui-render= twice on the same buffer no longer crashes
   when that buffer holds a =vui-field=. The first render leaves the field's
   =widget-after-change= hook on =after-change-functions= and the field itself in

--- a/test/vui-state-test.el
+++ b/test/vui-state-test.el
@@ -90,6 +90,37 @@
             (expect (plist-get (vui-instance-state instance) :count) :to-equal 5))
         (kill-buffer "*test-fn4*")))))
 
+(describe "vui-set-state value vs updater disambiguation"
+  ;; A functional update is a callable that takes the current value.  A value
+  ;; that is `functionp' but cannot be called with one argument - e.g. a data
+  ;; symbol like `cons', or `all' which became a builtin in Emacs 31 - must be
+  ;; stored as data, not mistaken for an updater and called.
+  (it "stores an fbound multi-argument symbol as data"
+    (vui-defcomponent ss-data-symbol ()
+      :state ((v nil))
+      :render (vui-text "x"))
+    (let ((instance (vui-mount (vui-component 'ss-data-symbol) "*ss-ds*")))
+      (unwind-protect
+          (let ((vui--current-instance instance))
+            ;; `cons' is fboundp and needs two args; before the fix this
+            ;; signalled (wrong-number-of-arguments cons 1)
+            (vui-set-state :v 'cons)
+            (expect (plist-get (vui-instance-state instance) :v) :to-equal 'cons))
+        (kill-buffer "*ss-ds*"))))
+
+  (it "still applies a one-argument function as a functional update"
+    (vui-defcomponent ss-fn-update ()
+      :state ((n 10))
+      :render (vui-text "x"))
+    (let ((instance (vui-mount (vui-component 'ss-fn-update) "*ss-fn*")))
+      (unwind-protect
+          (let ((vui--current-instance instance))
+            (vui-set-state :n #'1+)
+            (expect (plist-get (vui-instance-state instance) :n) :to-equal 11)
+            (vui-set-state :n (lambda (old) (* old 2)))
+            (expect (plist-get (vui-instance-state instance) :n) :to-equal 22))
+        (kill-buffer "*ss-fn*")))))
+
 (describe "vui-batch"
   (it "batches multiple state updates into single render"
     (let ((vui-render-delay nil)  ; Disable idle rendering

--- a/vui.el
+++ b/vui.el
@@ -1615,21 +1615,38 @@ or the nearest ancestor that has KEY, or INSTANCE as fallback."
     ;; Return found instance or original as fallback
     (or found instance)))
 
+(defun vui--state-updater-p (value)
+  "Non-nil if VALUE should be treated as a functional state updater.
+A functional update is a callable that takes the current value and returns
+the new one, so VALUE must be able to accept exactly one argument.  A value
+that is `functionp' but cannot - e.g. a data symbol like `all' (a builtin
+since Emacs 31) or `cons' that merely happens to be `fboundp' - is treated
+as a literal value, not an updater."
+  (and (functionp value)
+       (let ((arity (func-arity value)))
+         (and (<= (car arity) 1)
+              (or (eq (cdr arity) 'many)
+                  (>= (cdr arity) 1))))))
+
 (defun vui-set-state (key value)
   "Set state KEY to VALUE in the appropriate component and re-render.
 Searches for the component that owns KEY, starting from the current
 component and going up the parent chain.
 Must be called from within a component's event handler.
 
-If VALUE is a function, it is called with the current value and the
-result is used as the new value.  This is useful in async callbacks
-where the captured value may be stale:
+If VALUE is a function that accepts one argument, it is called with the
+current value and the result is used as the new value.  This is useful in
+async callbacks where the captured value may be stale:
 
   ;; Instead of (1+ count) which captures count at definition time:
   (vui-set-state :count #\\='1+)
 
   ;; Or with a lambda for more complex updates:
   (vui-set-state :items (lambda (old) (cons new-item old)))
+
+A value that cannot take one argument is stored as-is, so a data symbol
+that merely happens to be `fboundp' (e.g. \\='all, a builtin since Emacs 31)
+is kept literally rather than called (see `vui--state-updater-p').
 
 Treat state values as immutable: replace them (as both examples
 above do) rather than mutating them in place with setcar, push, or
@@ -1640,7 +1657,7 @@ sort.  In-place mutation is invisible to change detection
   (let* ((target (vui--find-state-owner vui--current-instance key))
          (current-state (vui-instance-state target))
          (current-value (plist-get current-state key))
-         (new-value (if (functionp value)
+         (new-value (if (vui--state-updater-p value)
                         (funcall value current-value)
                       value)))
     ;; No component in the chain declares KEY: almost certainly a typo.


### PR DESCRIPTION
Found while validating the examples on Emacs 31: clicking a filter button in the todo example crashes with `Wrong number of arguments: #<subr all>, 1`.

`vui-set-state` supports functional updates (`(vui-set-state :count #'1+)`), deciding via `(functionp value)`. Emacs 31 promoted `all` to a builtin function, so `(vui-set-state :filter 'all)` sees a "callable" symbol and runs `(all old-value)` -> boom. Any bare symbol used as a state value that happens to be `fboundp` hits this.

Fix: a value is only a functional updater if it's callable AND can accept exactly one argument (`vui--state-updater-p` via `func-arity`). `all`/`cons` (which need 2) are stored as data; `#'1+` and `(lambda (old) ...)` still update. Pre-existing bug, independent of the text-button work in #109.

Verified: the todo filter click works again, full suite green, clean compile + lint.