### PR TITLE
fix: vui-typed-field signals recovery via on-error nil on valid input

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -111,6 +111,14 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Fixed
 
+- =vui-typed-field= now signals recovery: its =:on-error= callback fires with
+  nil when input becomes valid again, not only with a message on failure.
+  Listeners that track validation errors - like the form examples, which gate
+  their submit button on a =(null errors)= check - previously could never clear
+  an error once a field had reported one, so a transient error (a half-typed
+  email) stuck forever and the button stayed disabled. This is why the contact,
+  registration and wizard examples could not be submitted. =:on-error= now
+  reports the current error state after each input (nil = valid).
 - =vui-set-state= no longer mistakes a data symbol that happens to be a
   function for a functional update. It ran VALUE on the current state whenever
   =(functionp value)= was non-nil, but Emacs 31 made =all= a builtin, so

--- a/test/vui-components-test.el
+++ b/test/vui-components-test.el
@@ -905,6 +905,43 @@ Buttons are widget.el push-buttons, so we use widget-apply."
                 (expect error-received :to-match "at least 10"))
             (kill-buffer "*test-typed-min*")))))
 
+    (it "calls on-error with nil when input recovers to valid"
+      ;; The clear signal: after reporting an error, recovering to valid input
+      ;; must notify on-error with nil so listeners tracking errors (like the
+      ;; form examples, which gate submit on a `null errors' check) can clear
+      ;; them.  Without this a transient error (e.g. a half-typed email) sticks
+      ;; forever and the submit button stays disabled.
+      (let ((calls '()))
+        (vui-defcomponent typed-recover-test ()
+          :render
+          (vui-typed-field :type 'integer
+                           :value 0
+                           :min 10
+                           :key 'test-field
+                           :on-error (lambda (err _raw) (push err calls))
+                           :on-change #'identity))
+        (let ((instance (vui-mount (vui-component 'typed-recover-test)
+                                    "*test-typed-recover*")))
+          (unwind-protect
+              (with-current-buffer "*test-typed-recover*"
+                ;; below min -> error.  Re-fetch the field before each input:
+                ;; a re-render recreates the widget, and real typing always
+                ;; goes through the current one.
+                (let ((widget (car widget-field-list)))
+                  (widget-value-set widget "5")
+                  (widget-apply widget :notify widget)
+                  (vui-flush-sync))
+                (let ((widget (car widget-field-list)))
+                  ;; valid -> should clear (on-error called with nil)
+                  (widget-value-set widget "20")
+                  (widget-apply widget :notify widget)
+                  (vui-flush-sync))
+                ;; most recent on-error call cleared the error...
+                (expect (car calls) :to-be nil)
+                ;; ...and there was a real error before it
+                (expect (seq-some #'identity calls) :to-be-truthy))
+            (kill-buffer "*test-typed-recover*")))))
+
     (it "does not call on-change when validation fails"
       (let ((change-received nil)
             (error-received nil))

--- a/vui-components.el
+++ b/vui-components.el
@@ -567,7 +567,13 @@ PLACEHOLDER is hint text shown while the field is empty."
                           (vui-set-state :error-msg validation-err)
                           (when on-error
                             (funcall on-error validation-err string-input)))
-                      ;; All valid
+                      ;; All valid.  Notify on-error with nil so listeners
+                      ;; tracking error state (e.g. a form that gates submit on
+                      ;; `null errors') clear any error they recorded for this
+                      ;; field; without this a transient error (a half-typed
+                      ;; email) sticks and the submit button stays disabled.
+                      (when on-error
+                        (funcall on-error nil string-input))
                       (vui-set-state :error-msg nil)
                       (vui-set-state :synced-value typed-value)
                       (when callback
@@ -605,7 +611,9 @@ PROPS is a plist accepting:
   :validate   - (lambda (typed-value) error-string-or-nil)
   :on-change  - (lambda (typed-value)) called only when valid
   :on-submit  - (lambda (typed-value)) called only when valid on RET
-  :on-error   - (lambda (error-msg raw-input)) on parse/validation failure
+  :on-error   - (lambda (error-msg raw-input)) with the current error state
+                after each input: the message on parse/validation failure, or
+                nil when the input is valid (so listeners can clear it)
   :show-error - t or \\='below for below, \\='inline for same line
   :size       - Field width
   :secret     - Password mode


### PR DESCRIPTION
Found while validating examples: the contact, registration, and wizard forms (`docs/examples/03-forms.el`) can't be submitted — the Submit/Next button stays disabled even with everything filled in.

Root cause: those forms gate the button on `:disabled (not valid-p)`, where `valid-p` includes `(null errors)`. `errors` is populated by each field's `:on-error` callback. But `vui-typed-field` only calls `:on-error` on *failure* — never on success. So once a field reports an error (e.g. the email while you're half-way through typing `b@x.io`), it's never cleared, `valid-p` stays nil, and the button stays disabled forever.

Fix: `vui-typed-field` now calls `:on-error` with `nil` when input is valid, i.e. `:on-error` reports the current error state after each input (nil = valid), so listeners can clear. One-line behavioural change in `handle-input`'s success branch, plus a docstring update.

Pre-existing, independent of the button/text-nav work. Verified: new unit test (typed-field clears its error on recovery), and end-to-end the contact and registration forms reach `errors=nil` and submit once filled. Full suite green, clean lint.