### PR TITLE
feat: public element-at-point API so consumers do not depend on the rendering mechanism

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -9,6 +9,21 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 ** Added
 
+- A public element-at-point API so consumers stop depending on the rendering
+  mechanism. =vui-element-at= returns the vui element at point (a button,
+  checkbox, select or field) as an opaque handle; =vui-element-get= reads its
+  vui properties (=:vui-key=, =:vui-tag=, =:vui-path=, ...); =vui-key-at= is
+  the convenience for the common "which keyed row is the cursor on" question;
+  and =vui-activate= runs the element's action (follow a link, toggle a
+  checkbox, submit a field). All four are mechanism-agnostic: they hide
+  whether vui rendered the element as a =button.el= text button or a
+  =widget.el= field. When #109 swapped buttons from widgets to text buttons it
+  silently broke consumers reaching for =(widget-at (point))= and
+  =(widget-get ... :vui-key)=, which return nil for text buttons - the same
+  lesson as the cursor-identity fix, which only survived because vui already
+  abstracted the two internally (=vui--elt-get=). This extends that
+  abstraction outward, so a future rendering refactor is no longer a breaking
+  change for anyone downstream (#113).
 - =vui-goto-key= moves point onto the widget carrying a given reconciliation
   =:key= (matched with =equal=), returning its position or nil. Handy for
   steering point to a known row, e.g. parking it on a stable anchor before a

--- a/README.org
+++ b/README.org
@@ -429,6 +429,23 @@ Packages can derive their own modes from =vui-mode= to add custom keybindings:
 
 When using a derived mode, enable it *before* calling =vui-mount= or =vui-render=. VUI will detect the derived mode and preserve it across re-renders.
 
+* Querying Elements at Point
+
+When you bind your own key or command, you often need to know which VUI element the cursor is on and act on it. Reach for these instead of =widget-at= / =button-at=: they are *mechanism-agnostic*. VUI renders buttons, checkboxes and selects as =button.el= text buttons and editable fields as =widget.el= widgets, and these functions hide that difference. Poking at the rendering mechanism directly breaks whenever it changes; this API does not.
+
+- =(vui-element-at &optional POS)= — the VUI element at POS (default point), or =nil=. An opaque handle; don't assume how it was rendered.
+- =(vui-element-get ELEMENT PROP)= — a VUI property of ELEMENT: =:vui-key= (reconciliation key), =:vui-tag= (label), =:vui-path= (component-tree path), and so on.
+- =(vui-key-at &optional POS)= — convenience for the common case: the =:key= of the element at POS, or =nil=. Same as =(vui-element-get (vui-element-at POS) :vui-key)=.
+- =(vui-activate &optional POS)= — run the element's action: follow a button, toggle a checkbox, open a select, submit a field. Returns non-nil when an element was found.
+
+#+begin_src elisp
+;; A command that opens whatever keyed row the cursor is on.
+(defun my-open-at-point ()
+  (interactive)
+  (when-let* ((key (vui-key-at)))
+    (my-open-note key)))
+#+end_src
+
 * Architecture
 
 vui.el implements a React-like architecture:

--- a/test/vui-element-api-test.el
+++ b/test/vui-element-api-test.el
@@ -1,0 +1,154 @@
+;;; vui-element-api-test.el --- Public element-at-point API tests -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025-2026 Free Software Foundation, Inc.
+
+;;; Commentary:
+
+;; vui renders interactive elements with two mechanisms: `button.el' text
+;; buttons (buttons, checkboxes, selects) and `widget.el' editable fields
+;; (issues #107/#109).  Consumers must not have to know which - "what vui
+;; element is at point, and what are its properties" is a public contract
+;; (`vui-element-at', `vui-element-get', `vui-key-at', `vui-activate') that
+;; hides the mechanism, so a rendering refactor like #109 stops being a
+;; breaking change for them (issue #113).
+;;
+;; The load-bearing property of every spec below: not one of them names
+;; `button-at', `widget-field-at', `button-get' or `widget-get'.  A button
+;; and a field are queried through the exact same calls; if a future refactor
+;; swaps a mechanism, these keep passing.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'vui)
+
+(defun vui-element-api-test--field-start ()
+  "Return the start position of the first editable field in the buffer."
+  (widget-field-start (car widget-field-list)))
+
+(describe "vui-element-at"
+  (it "returns the text button at POS"
+    (with-temp-buffer
+      (vui-render (vui-button "click" :on-click #'ignore) (current-buffer))
+      (let ((elt (vui-element-at (point-min))))
+        (expect elt :to-be-truthy)
+        (expect (vui-element-get elt :vui-tag) :to-equal "click"))))
+
+  (it "returns the editable field at POS with the same call"
+    (with-temp-buffer
+      (vui-render (vui-field :size 6 :key 'f) (current-buffer))
+      (let ((elt (vui-element-at (vui-element-api-test--field-start))))
+        (expect elt :to-be-truthy)
+        (expect (vui-element-get elt :vui-key) :to-equal 'f))))
+
+  (it "defaults POS to point"
+    (with-temp-buffer
+      (vui-render (vui-button "here" :on-click #'ignore) (current-buffer))
+      (goto-char (point-min))
+      (expect (vui-element-get (vui-element-at) :vui-tag) :to-equal "here")))
+
+  (it "returns nil when POS holds no interactive element"
+    (with-temp-buffer
+      (vui-render (vui-text "just text") (current-buffer))
+      (expect (vui-element-at (point-min)) :to-be nil))))
+
+(describe "vui-element-get"
+  (it "reads vui properties off a text button"
+    (with-temp-buffer
+      (vui-render (vui-vstack (vui-button "Save" :key 'save :on-click #'ignore))
+                  (current-buffer))
+      (let ((elt (vui-element-at (point-min))))
+        (expect (vui-element-get elt :vui-key) :to-equal 'save)
+        (expect (vui-element-get elt :vui-tag) :to-equal "Save")
+        (expect (vui-element-get elt :vui-path) :to-equal '(0)))))
+
+  (it "reads vui properties off an editable field with the identical call"
+    ;; The caller never learns that the field is a widget and the button is
+    ;; not: the same accessor serves both.
+    (with-temp-buffer
+      (vui-render (vui-field :size 6 :key 'name) (current-buffer))
+      (let ((elt (vui-element-at (vui-element-api-test--field-start))))
+        (expect (vui-element-get elt :vui-key) :to-equal 'name)))))
+
+(describe "vui-key-at"
+  (it "returns the key of the text button at POS"
+    (with-temp-buffer
+      (vui-render (vui-button "Go" :key 'go :on-click #'ignore) (current-buffer))
+      (expect (vui-key-at (point-min)) :to-equal 'go)))
+
+  (it "returns the key of the editable field at POS"
+    (with-temp-buffer
+      (vui-render (vui-field :size 6 :key 'email) (current-buffer))
+      (expect (vui-key-at (vui-element-api-test--field-start)) :to-equal 'email)))
+
+  (it "defaults POS to point"
+    (with-temp-buffer
+      (vui-render (vui-button "Go" :key 'go :on-click #'ignore) (current-buffer))
+      (goto-char (point-min))
+      (expect (vui-key-at) :to-equal 'go)))
+
+  (it "returns nil when the element carries no key"
+    (with-temp-buffer
+      (vui-render (vui-button "Anon" :on-click #'ignore) (current-buffer))
+      (expect (vui-key-at (point-min)) :to-be nil)))
+
+  (it "returns nil when POS holds no interactive element"
+    (with-temp-buffer
+      (vui-render (vui-text "plain") (current-buffer))
+      (expect (vui-key-at (point-min)) :to-be nil))))
+
+(describe "vui-activate"
+  (it "runs a text button's action (the follow case)"
+    (let ((hit nil))
+      (with-temp-buffer
+        (vui-render (vui-button "go" :on-click (lambda () (setq hit t)))
+                    (current-buffer))
+        (expect (vui-activate (point-min)) :to-be-truthy))
+      (expect hit :to-be t)))
+
+  (it "toggles a checkbox (the toggle case)"
+    (let ((new-value :unset))
+      (with-temp-buffer
+        (vui-render (vui-checkbox :checked nil
+                                  :on-change (lambda (v) (setq new-value v)))
+                    (current-buffer))
+        (vui-activate (point-min)))
+      (expect new-value :to-be t)))
+
+  (it "submits an editable field (its :action)"
+    (let ((submitted nil))
+      (with-temp-buffer
+        (vui-render (vui-field :size 6 :key 'f :value "hi"
+                               :on-submit (lambda (v) (setq submitted v)))
+                    (current-buffer))
+        (expect (vui-activate (vui-element-api-test--field-start))
+                :to-be-truthy))
+      (expect submitted :to-equal "hi")))
+
+  (it "defaults POS to point"
+    (let ((hit nil))
+      (with-temp-buffer
+        (vui-render (vui-button "go" :on-click (lambda () (setq hit t)))
+                    (current-buffer))
+        (goto-char (point-min))
+        (vui-activate))
+      (expect hit :to-be t)))
+
+  (it "reports the element but leaves a disabled button inert"
+    (let ((hit nil))
+      (with-temp-buffer
+        (vui-render (vui-button "no" :disabled t
+                                :on-click (lambda () (setq hit t)))
+                    (current-buffer))
+        ;; An element is present, so activate reports it...
+        (expect (vui-activate (point-min)) :to-be-truthy)
+        ;; ...but the disabled button's own action no-ops.
+        (expect hit :to-be nil))))
+
+  (it "returns nil when POS holds no interactive element"
+    (with-temp-buffer
+      (vui-render (vui-text "plain") (current-buffer))
+      (expect (vui-activate (point-min)) :to-be nil))))
+
+(provide 'vui-element-api-test)
+;;; vui-element-api-test.el ends here

--- a/vui.el
+++ b/vui.el
@@ -2793,6 +2793,66 @@ selects) or a `widget.el' editable field."
   "Get PROP of interactive element ELT (a text button or a widget field)."
   (if (widgetp elt) (widget-get elt prop) (button-get elt prop)))
 
+;;; Public element-at-point API
+;;
+;; vui renders interactive elements with two mechanisms - `button.el' text
+;; buttons (buttons, checkboxes, selects) and `widget.el' editable fields
+;; (issues #107/#109) - and hides the difference behind the `vui--elt-*'
+;; helpers above.  These functions give that abstraction a public face, so a
+;; consumer can ask "what vui element is at point, and what are its
+;; properties" without reaching for `button-at'/`widget-at' or
+;; `button-get'/`widget-get'.  That keeps the rendering mechanism an internal
+;; detail vui is free to change: a refactor like #109 (widgets -> text
+;; buttons) stops being a breaking change for everyone downstream (issue #113).
+
+(defun vui-element-at (&optional pos)
+  "Return the vui interactive element at POS, or nil.
+POS defaults to point.  The element is whatever vui rendered there - a
+text button (a vui button, checkbox or select) or an editable field -
+returned as an opaque handle.  Read its properties with `vui-element-get'
+and run its action with `vui-activate'.  Do not assume which rendering
+mechanism produced the handle: that is vui's to change (issue #113)."
+  (vui--elt-at (or pos (point))))
+
+(defun vui-element-get (element prop)
+  "Return vui property PROP of ELEMENT, or nil.
+ELEMENT is a handle from `vui-element-at'.  PROP is one of vui's element
+properties - `:vui-key' (the reconciliation key), `:vui-tag' (the label),
+`:vui-path' (the component-tree path) and the like.  This reads them the
+same way whichever mechanism rendered ELEMENT, so consumers never call
+`widget-get' or `button-get' directly and stay insulated from a rendering
+change (issue #113)."
+  (vui--elt-get element prop))
+
+(defun vui-key-at (&optional pos)
+  "Return the reconciliation `:key' of the vui element at POS, or nil.
+POS defaults to point.  Returns nil when POS holds no vui element, or the
+element carries no key.  A convenience for the common case of asking which
+keyed row - a note, an item, a choice - the cursor sits on; equivalent to
+\(vui-element-get (vui-element-at POS) :vui-key)."
+  (when-let* ((elt (vui--elt-at (or pos (point)))))
+    (vui--elt-get elt :vui-key)))
+
+(defun vui-activate (&optional pos)
+  "Activate the vui element at POS, running its action.
+POS defaults to point.  Runs whatever the element does when pushed: a
+button follows its `:on-click', a checkbox toggles, a select opens its
+menu, an editable field submits (`:on-submit').  Returns non-nil when an
+element was found at POS (and its action invoked), nil when POS holds none.
+
+Mechanism-agnostic on purpose: activation is itself where the rendering
+mechanism used to leak (`push-button' for a button, `widget-apply' for a
+field), so a consumer calls this and a rendering change never reaches it
+\(issue #113).  A disabled button is still reported here, but its own
+action no-ops."
+  (interactive)
+  (when-let* ((elt (vui--elt-at (or pos (point)))))
+    (if (widgetp elt)
+        (when (widget-get elt :action)
+          (widget-apply elt :action))
+      (button-activate elt))
+    t))
+
 (defun vui--widget-bounds (elt)
   "Return (START . END) bounds of interactive element ELT, or nil.
 For an editable field, the editable text area (not decoration); for a


### PR DESCRIPTION
Makes "what vui element is at point, and what are its properties" part of vui's public contract, so the rendering mechanism (button.el vs widget.el) stays an internal detail instead of leaking to consumers.

When #109 switched buttons, checkboxes and selects from widget.el widgets to button.el text buttons, it silently broke consumers reaching for `(widget-at (point))` and `(widget-get ... :vui-key)`: those return nil for a text button. vui itself survived because it abstracts the two internally via `vui--elt-get`, but consumers had no public equivalent, so they poked at the mechanism directly. This just gives that abstraction a public face:

- `vui-element-at` - the element at point, or nil (opaque handle)
- `vui-element-get` - read a vui property (`:vui-key`, `:vui-tag`, `:vui-path`, ...) the same way whichever mechanism rendered it
- `vui-key-at` - convenience for the common "which keyed row is the cursor on" case
- `vui-activate` - run the element's action (follow a button, toggle a checkbox, open a select, submit a field). Activation is itself where the mechanism leaked (`push-button` vs `widget-apply`), so it belongs behind the same wall.

Now a rendering refactor like #109 stops being a breaking change for anyone downstream. README and CHANGELOG updated.

Closes #113.
