### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -7,6 +7,8 @@ The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]
 
 * Unreleased
 
+* v1.3.0 - 2026-07-02
+
 ** Added
 
 - A public element-at-point API so consumers stop depending on the rendering

--- a/vui.el
+++ b/vui.el
@@ -6,7 +6,7 @@
 ;; Author: Boris Buliga <boris@d12frosted.io>
 ;; Maintainer: Boris Buliga <boris@d12frosted.io>
 ;; URL: https://github.com/d12frosted/vui.el
-;; Version: 1.2.0
+;; Version: 1.3.0
 ;; Package-Requires: ((emacs "29.1"))
 ;; Keywords: ui, widgets, tools
 


### PR DESCRIPTION
Cuts v1.3.0. Bumps the `Version:` header in vui.el to 1.3.0 and rolls the CHANGELOG `* Unreleased` section over to `* v1.3.0 - 2026-07-02` (leaving a fresh empty Unreleased on top).

By semver this is a minor release: lots of new, backward-compatible functionality (the `vui-stream` arc, `:memo`, `vui-goto-key`, rich collapsible headers, the element-at-point API) plus fixes; the button.el migration is internal (the only externally visible bit is a button's RET binding being `push-button` rather than `widget-button-press`), no public API breaks.

After this merges: tag `v1.3.0` and publish the GitHub release with the notes below.

---

## Draft release notes (for the GitHub release) — please review the Thanks list

The biggest release since 1.0. Four things stand out.

## Buttons are just text now (and much faster for it)

Buttons, checkboxes and selects used to be `widget.el` widgets, which meant a live marker or two per element, and Emacs adjusts every live marker on every insert, so a button-heavy buffer rendered in O(n^2) and a big enough one could crash Emacs. They are now `button.el` text buttons: marker-free, roughly as cheap as plain text (a flat ~3us/row), and the whole quadratic cliff is gone. A ~6000-row schema dashboard that took ~8.5s now builds in ~0.1s. Editable fields stay on `widget.el` (still the only battle-tested in-buffer text editing). Navigation (TAB/S-TAB), cursor tracking and keymaps all got simpler as a result, because a button is now just text with properties.

There is also a public element-at-point API so consumers can find the interactive element under point without reaching into the rendering internals (#113).

## Cursor preservation that follows structure, not buffer position

Re-renders now recover point semantically. When the row point was on is removed, it recovers to the nearest surviving element in the component tree (the sibling that slid into its slot, the previous sibling, or an ancestor) instead of dropping to the top of the buffer. Identity tracking got sharper too: point follows an element by its reconciliation `:key`, not just its label, so a counter button or a select whose text changes still keeps point, and `vui-goto-key` lets you steer point onto a known element by key.

## Experimental incremental rendering

An opt-in path (`vui-incremental-render`) that patches only what changed instead of rebuilding the buffer, plus the always-on cheap wins that came with it: a whole-tree `eq` skip (a no-op re-render is O(1)), O(n) list reconciliation (was O(n^2)), and a `:memo` shorthand for the common `:should-update`. Experimental, but the foundation for signals and virtualization later.

## vui-stream: append-only streaming (also experimental)

An imperative, append-only region for unbounded streaming content, chat transcripts and build logs, the one shape the declarative "re-render from state" model is too slow for. Append is O(1); a growing 4000-item stream stays flat where the declarative rebuild is ~950x slower and rising. Items can be plain content or stateful component rows, there are random-access node handles for out-of-order edits (a tool card that appears mid-reply), and a sibling "box" below the stream can update without re-emitting the whole transcript. This is the main thing the incremental work was built to enable.

## Everything else

13 bug fixes plus internal and documentation improvements. See the CHANGELOG for the full list.

## Thanks

Huge thanks to [@ananthakumaran](https://github.com/ananthakumaran), whose ideas seeded most of the experimental work here, and who wrote the Claude UI example. And to Charlie Holland, for the nudge to keep pushing on the examples.

Thanks also to everyone who has opened issues and PRs on vui.el: @DamienCassou, @a-nigredo, @ahyatt, @emarsden, @kilesduli, @phil-s, @wiresong, @zonuexe.

---

**Acknowledgments note:** the "everyone who opened issues and PRs" list is every external issue/PR author on the repo (all v1.3.0 changelog refs were opened by you, so none map to a specific fix; I credited them as general contributors rather than tie them to fixes they did not file). Trim or reword as you like. Charlie Holland is credited by name (no GitHub handle given).